### PR TITLE
compositor: correct use of logfile

### DIFF
--- a/server/compositor.c
+++ b/server/compositor.c
@@ -41,8 +41,6 @@
 #include "taiwins.h"
 #include "compositor.h"
 
-FILE *logfile;
-
 static struct xkb_rule_names default_xkb_rules = {0};
 
 static void
@@ -139,7 +137,7 @@ int main(int argc, char *argv[])
 	struct tw_config *config;
 	char path[PATH_MAX];
 
-	logfile = fopen("/tmp/taiwins_log", "w");
+	tw_logfile = fopen("/tmp/taiwins_log", "w");
 	weston_log_set_handler(tw_log, tw_log);
 
 	tw_compositor_get_socket(path);

--- a/server/taiwins.c
+++ b/server/taiwins.c
@@ -34,12 +34,14 @@
 
 #include "taiwins.h"
 
-FILE *logfile;
+FILE *tw_logfile = NULL;
 
 int
 tw_log(const char *format, va_list args)
 {
-	return vfprintf(logfile, format, args);
+	if (tw_logfile)
+		return vfprintf(tw_logfile, format, args);
+	return -1;
 }
 
 static int

--- a/server/taiwins.h
+++ b/server/taiwins.h
@@ -22,6 +22,7 @@
 #ifndef TAIWINS_H
 #define TAIWINS_H
 
+#include <stdio.h>
 #include <stdarg.h>
 #include <ctypes/helpers.h>
 #include <wayland-server.h>
@@ -49,6 +50,8 @@ struct tw_config;
 /*******************************************************************************
  * logging functions
  ******************************************************************************/
+extern FILE *tw_logfile;
+
 int
 tw_log(const char *format, va_list args);
 


### PR DESCRIPTION
There were two definitions of tw_logfile, strangely gcc compiled without
problem.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>