### PR TITLE
libinput: testing only for BTN_LEFT when getting new input device.

### DIFF
--- a/server/backend/backend_libinput.c
+++ b/server/backend/backend_libinput.c
@@ -55,8 +55,7 @@ validate_keyboard(struct libinput_device *dev)
 static bool
 validate_pointer(struct libinput_device *dev)
 {
-	return libinput_device_pointer_has_button(dev, BTN_LEFT) &&
-		libinput_device_pointer_has_button(dev, BTN_RIGHT);
+	return libinput_device_pointer_has_button(dev, BTN_LEFT);
 }
 
 static bool


### PR DESCRIPTION
Signed-off-by: Xichen Zhou <xzhou@xeechou.net>