### PR TITLE
session_switch grab for VT switch.

### DIFF
--- a/server/backend/backend.c
+++ b/server/backend/backend.c
@@ -30,6 +30,7 @@
 #include <wayland-util.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
+#include <wlr/backend/multi.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_cursor.h>
@@ -348,5 +349,17 @@ tw_backend_add_listener(struct tw_backend *backend,
 	case TW_BACKEND_CH_SEAT:
 		wl_signal_add(&backend->seat_ch_signal, listener);
 		break;
+	}
+}
+
+void
+tw_backend_switch_session(struct tw_backend *backend, uint32_t id)
+{
+	struct wlr_session *session;
+
+	if (id > 0 && id <= 7 && wlr_backend_is_multi(backend->auto_backend)) {
+		session = wlr_backend_get_session(backend->auto_backend);
+		if (session)
+			wlr_session_change_vt(session, id);
 	}
 }

--- a/server/include/backend.h
+++ b/server/include/backend.h
@@ -283,6 +283,8 @@ tw_backend_seat_set_xkb_rules(struct tw_backend_seat *seat,
 void
 tw_backend_set_repeat_info(struct tw_backend *backend,
                            unsigned int rate, unsigned int delay);
+void
+tw_backend_switch_session(struct tw_backend *backend, uint32_t session);
 
 #ifdef  __cplusplus
 }

--- a/server/input.h
+++ b/server/input.h
@@ -35,6 +35,7 @@ extern "C" {
 
 struct tw_seat_events {
 	struct tw_seat *seat;
+	struct tw_backend *backend;
 	struct tw_bindings *bindings;
 	struct wlr_keyboard *keyboard_dev;
 	struct wlr_pointer *pointer_dev;
@@ -47,6 +48,7 @@ struct tw_seat_events {
 	struct wl_listener axis_input;
 	struct wl_listener tch_input;
 
+	struct tw_seat_keyboard_grab session_switch_grab;
 	struct tw_seat_keyboard_grab binding_key_grab;
 	struct tw_seat_pointer_grab binding_pointer_grab;
 	struct tw_seat_touch_grab binding_touch_grab;

--- a/server/objects/seat/seat_keyboard.c
+++ b/server/objects/seat/seat_keyboard.c
@@ -145,9 +145,12 @@ tw_seat_remove_keyboard(struct tw_seat *seat)
 
 	seat->capabilities &= ~WL_SEAT_CAPABILITY_KEYBOARD;
 	tw_seat_send_capabilities(seat);
+
+	//now we remove the link of the resources, the resource itself would get
+	//destroyed in release request.
 	wl_list_for_each(client, &seat->clients, link)
 		wl_resource_for_each_safe(resource, next, &client->keyboards)
-			wl_resource_destroy(resource);
+			tw_reset_wl_list(wl_resource_get_link(resource));
 
 	if (keyboard->keymap_string)
 		free(keyboard->keymap_string);

--- a/server/objects/seat/seat_keyboard.c
+++ b/server/objects/seat/seat_keyboard.c
@@ -155,6 +155,7 @@ tw_seat_remove_keyboard(struct tw_seat *seat)
 	keyboard->keymap_size = 0;
 	keyboard->focused_client = NULL;
 	keyboard->focused_surface = NULL;
+	tw_reset_wl_list(&keyboard->focused_destroy.link);
 }
 
 void

--- a/server/objects/seat/seat_pointer.c
+++ b/server/objects/seat/seat_pointer.c
@@ -172,11 +172,14 @@ tw_seat_remove_pointer(struct tw_seat *seat)
 	struct wl_resource *resource, *next;
 	struct tw_pointer *pointer = &seat->pointer;
 
-	seat->capabilities &= ~WL_SEAT_CAPABILITY_KEYBOARD;
+	seat->capabilities &= ~WL_SEAT_CAPABILITY_POINTER;
 	tw_seat_send_capabilities(seat);
+
+	//now we remove the link of the resources, the resource itself would get
+	//destroyed in release request.
 	wl_list_for_each(client, &seat->clients, link)
 		wl_resource_for_each_safe(resource, next, &client->pointers)
-			wl_resource_destroy(resource);
+			tw_reset_wl_list(wl_resource_get_link(resource));
 
 	pointer->grab = &pointer->default_grab;
 	pointer->focused_client = NULL;

--- a/server/objects/seat/seat_pointer.c
+++ b/server/objects/seat/seat_pointer.c
@@ -181,6 +181,7 @@ tw_seat_remove_pointer(struct tw_seat *seat)
 	pointer->grab = &pointer->default_grab;
 	pointer->focused_client = NULL;
 	pointer->focused_surface = NULL;
+	tw_reset_wl_list(&pointer->focused_destroy.link);
 }
 
 void

--- a/server/objects/seat/seat_touch.c
+++ b/server/objects/seat/seat_touch.c
@@ -169,6 +169,7 @@ tw_seat_remove_touch(struct tw_seat *seat)
 	touch->grab = &touch->default_grab;
 	touch->focused_client = NULL;
 	touch->focused_surface = NULL;
+	tw_reset_wl_list(&touch->focused_destroy.link);
 }
 
 void

--- a/server/objects/seat/seat_touch.c
+++ b/server/objects/seat/seat_touch.c
@@ -160,11 +160,14 @@ tw_seat_remove_touch(struct tw_seat *seat)
 	struct wl_resource *resource, *next;
 	struct tw_touch *touch = &seat->touch;
 
-	seat->capabilities &= ~WL_SEAT_CAPABILITY_KEYBOARD;
+	seat->capabilities &= ~WL_SEAT_CAPABILITY_TOUCH;
 	tw_seat_send_capabilities(seat);
+
+	//now we remove the link of the resources, the resource itself would get
+	//destroyed in release request.
 	wl_list_for_each(client, &seat->clients, link)
 		wl_resource_for_each_safe(resource, next, &client->touches)
-			wl_resource_destroy(resource);
+			tw_reset_wl_list(wl_resource_get_link(resource));
 
 	touch->grab = &touch->default_grab;
 	touch->focused_client = NULL;


### PR DESCRIPTION
The wl_seat global unregistering has some problems cause the client to crash.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>