### PR TITLE
drm: measure render_output frame time

### DIFF
--- a/libtaiwins/backend/drm/drm.c
+++ b/libtaiwins/backend/drm/drm.c
@@ -20,6 +20,7 @@
  */
 
 #include <assert.h>
+#include <time.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -255,6 +256,12 @@ tw_drm_check_gpu_features(struct tw_drm_gpu *gpu)
 		return false;
 	} else {
 		gpu->feats |= TW_DRM_CAP_PRIME;
+	}
+	if (drmGetCap(fd, DRM_CAP_TIMESTAMP_MONOTONIC, &cap) == 0) {
+		if (cap == 1)
+			gpu->clk_id = CLOCK_MONOTONIC;
+	} else {
+		gpu->clk_id = CLOCK_REALTIME;
 	}
 
 	if (drmGetCap(fd, DRM_CAP_ADDFB2_MODIFIERS, &cap) == 0) {

--- a/libtaiwins/backend/drm/internal.h
+++ b/libtaiwins/backend/drm/internal.h
@@ -224,6 +224,7 @@ struct tw_drm_gpu {
 	bool boot_vga;
 	bool activated; /**< valid gpu otherwise not used */
 	uint32_t visual_id;
+	clockid_t clk_id;
 
 	struct wl_list link; /* backend:gpu_list */
 


### PR DESCRIPTION
The measurement will be used later for predict rendertime.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>