### PR TITLE
render: handle render_output destroy on exit

### DIFF
--- a/libtaiwins/backend/drm/display.c
+++ b/libtaiwins/backend/drm/display.c
@@ -483,7 +483,8 @@ tw_drm_display_stop(struct tw_drm_display *output)
 		crtc_from_id(output->gpu, output->status.crtc_id);
 	tw_reset_wl_list(&output->presentable_commit.link);
 	tw_output_device_commit_state(&output->output.device);
-	tw_render_output_unset_context(&output->output);
+	if (output->output.ctx)
+		tw_render_output_unset_context(&output->output);
 	output->status.unset_crtc = NULL;
 }
 

--- a/libtaiwins/render/render_output.c
+++ b/libtaiwins/render/render_output.c
@@ -24,6 +24,7 @@
 #include <pixman.h>
 #include <stdint.h>
 #include <string.h>
+#include <wayland-server-core.h>
 #include <wayland-server.h>
 #include <taiwins/objects/utils.h>
 #include <taiwins/objects/logger.h>


### PR DESCRIPTION
When we exiting compositor, render_output would unset context, which in turn
cause every wl_surfaces to re-assign outputs. Previously wl_surfaces would
assume there is always an output to assign but it is not the case.

This fix only handle this issue, we need to truly tackle the output lost
problem for wl_surfaces.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>