### PR TITLE
frame reschedule 

### DIFF
--- a/compositor/main.c
+++ b/compositor/main.c
@@ -47,6 +47,7 @@
 #include <taiwins/render_pipeline.h>
 
 #include "input.h"
+#include "output.h"
 #include "render.h"
 #include "desktop/xdg.h"
 #include "config/config.h"
@@ -67,9 +68,10 @@ struct tw_server {
 	struct tw_backend *backend;
 	struct tw_engine *engine;
 	struct tw_render_context *ctx;
-	struct tw_config config;
+        struct tw_config config;
+	struct tw_server_output_manager *output_manager;
 
-	/* seats */
+        /* seats */
 	struct tw_seat_listeners seat_listeners[8];
 	struct wl_listener seat_add;
 	struct wl_listener seat_remove;
@@ -127,6 +129,9 @@ notify_removing_seat(struct wl_listener *listener, void *data)
 static void
 bind_listeners(struct tw_server *server)
 {
+	server->output_manager =
+		tw_server_output_manager_create_global(server->engine,
+		                                       server->ctx);
 	tw_signal_setup_listener(&server->engine->signals.seat_created,
 	                         &server->seat_add,
 	                         notify_adding_seat);

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -6,6 +6,10 @@ elif get_option('rendering-debug') == 'clip'
   taiwins_cargs += '-D_TW_DEBUG_CLIP'
 endif
 
+if get_option('enable-profiler')
+  taiwins_cargs += '-D_TW_ENABLE_PROFILING'
+endif
+
 if get_option('xwayland').enabled()
   taiwins_cargs += '-D_TW_HAS_XWAYLAND'
 endif
@@ -14,6 +18,7 @@ endif
 taiwins_src = [
   'main.c',
   'input.c',
+  'output.c',
   'bindings.c',
   'egl_renderer.c',
 

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -1,0 +1,401 @@
+/*
+ * output.c - taiwins server output implementation
+ *
+ * Copyright (c) 2021 Xichen Zhou
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <pixman.h>
+#include <wayland-server-core.h>
+#include <wayland-server.h>
+#include <taiwins/objects/utils.h>
+#include <taiwins/engine.h>
+#include <taiwins/backend.h>
+#include <taiwins/profiling.h>
+#include <taiwins/render_output.h>
+#include <taiwins/render_context.h>
+#include <taiwins/render_surface.h>
+#include <ctypes/helpers.h>
+#include <wayland-util.h>
+
+#include "output.h"
+
+static void
+tw_server_output_fini(struct tw_server_output *output);
+
+static inline void
+update_output_frame_time(struct tw_server_output *output,
+                         const struct timespec *strt,
+                         const struct timespec *end)
+{
+	uint32_t ft;
+	uint64_t tstart = tw_timespec_to_us(strt);
+	uint64_t tend = tw_timespec_to_us(end);
+
+	/* assert(tend >= tstart); */
+	ft = MAX((uint32_t)0, (uint32_t)(tend - tstart));
+	output->state.fts[output->state.ft_idx] = ft;
+	output->state.ft_idx = (output->state.ft_idx + 1) % TW_FRAME_TIME_CNT;
+}
+
+/* getting the max frame time in milliseconds */
+static inline uint32_t
+calc_output_max_frametime(struct tw_server_output *output)
+{
+	uint32_t *fts = output->state.fts;
+	uint32_t ft = MAX(MAX(MAX(fts[0], fts[1]), MAX(fts[2],fts[3])),
+	                  MAX(MAX(fts[4], fts[5]), MAX(fts[6],fts[7])));
+	//ceil algorithm, output basically
+	return ft ? ((ft + 1000) / 1000) : ft;
+}
+
+/******************************************************************************
+ * surface output relations
+ *****************************************************************************/
+
+static void
+update_surface_mask(struct tw_surface *base, struct tw_engine *engine,
+                    struct tw_render_output *major, uint32_t mask)
+{
+	struct tw_engine_output *output;
+	struct tw_render_surface *surface =
+		wl_container_of(base, surface, surface);
+	uint32_t output_bit;
+	uint32_t different = surface->output_mask ^ mask;
+	uint32_t entered = mask & different;
+	uint32_t left = surface->output_mask & different;
+
+	//update the surface_mask and
+	surface->output_mask = mask;
+	surface->output = major ? major->device.id : -1;
+
+	wl_list_for_each(output, &engine->heads, link) {
+
+		output_bit = 1u << output->device->id;
+		if (!(output_bit & different))
+			continue;
+		if ((output_bit & entered))
+			tw_engine_output_notify_surface_enter(output, base);
+		if ((output_bit & left))
+			tw_engine_output_notify_surface_leave(output, base);
+	}
+}
+
+/* we employ the same logic for surface output assigning in weston, compares
+ * the surface 2D geometry against the output
+ */
+static void
+reassign_surface_outputs(struct tw_render_surface *render_surface,
+                         struct tw_render_context *ctx,
+                         struct tw_engine *engine)
+{
+	uint32_t area = 0, max = 0, mask = 0;
+	struct tw_render_output *output, *major = NULL;
+	pixman_region32_t surface_region;
+	pixman_box32_t *e;
+	struct tw_surface *surface = &render_surface->surface;
+
+	pixman_region32_init_rect(&surface_region,
+	                          surface->geometry.xywh.x,
+	                          surface->geometry.xywh.y,
+	                          surface->geometry.xywh.width,
+	                          surface->geometry.xywh.height);
+	wl_list_for_each(output, &ctx->outputs, link) {
+		pixman_region32_t clip;
+		struct tw_output_device *device = &output->device;
+		pixman_rectangle32_t rect =
+			tw_output_device_geometry(device);
+		//TODO dealing with cloning output
+		// if (output->cloning >= 0)
+		//	continue;
+		pixman_region32_init_rect(&clip, rect.x, rect.y,
+		                          rect.width, rect.height);
+		pixman_region32_intersect(&clip, &clip, &surface_region);
+		e = pixman_region32_extents(&clip);
+		area = (e->x2 - e->x1) * (e->y2 - e->y1);
+		if (pixman_region32_not_empty(&clip))
+			mask |= (1u << device->id);
+		if (area >= max) {
+			major = output;
+			max = area;
+		}
+		pixman_region32_fini(&clip);
+	}
+	pixman_region32_fini(&surface_region);
+
+	update_surface_mask(surface, engine, major, mask);
+}
+
+/******************************************************************************
+ * output listeners
+ *****************************************************************************/
+
+static int
+notify_output_frame(void *data)
+{
+	struct tw_server_output *output = data;
+	struct tw_render_output *render_output =
+		wl_container_of(output->output->device, render_output, device);
+	tw_render_output_post_frame(render_output);
+	return 0;
+}
+
+static void
+notify_output_reshedule_frame(struct wl_listener *listener, void *data)
+{
+	int delay, ms_left = 0; //< left for render
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.need_frame);
+	struct tw_output_device *device = data;
+
+	int frametime = calc_output_max_frametime(output);
+
+	assert(output->output->device == device);
+	if (!device->current.enabled)
+		return;
+
+	if (frametime) { //becomes max_render_time
+		struct timespec now;
+		//get current time as soon as possible
+		clock_gettime(device->clk_id, &now);
+
+		struct timespec predict_refresh = output->state.last_present;
+		unsigned mhz = device->current.current_mode.refresh;
+		uint32_t refresh = tw_millihertz_to_ns(mhz);
+
+		//getting a predicted vblank. 1): If we are scheduled right
+		//after a vsync, there are chance predict_refresh is ahead of
+		//us. 2) If we come from a idle frame, predict_time will be
+		//less than now, in that case, we just draw
+
+		predict_refresh.tv_nsec += refresh % TW_NS_PER_S;
+		predict_refresh.tv_sec += refresh / TW_NS_PER_S;
+		if (predict_refresh.tv_nsec >= TW_NS_PER_S) {
+			predict_refresh.tv_sec += 1;
+			predict_refresh.tv_nsec -= TW_NS_PER_S;
+		}
+
+		//this is the floored difference.
+		if (predict_refresh.tv_sec >= now.tv_sec)
+			ms_left = tw_timespec_diff_ms(&predict_refresh, &now);
+	}
+	//here we added 2 extra ms frametime, it seems with amount, we are
+	//able to catch up with next vblank. TODO we can we not rely on this,
+	//otherwise we would have to move this repaint logic out of libtaiwins.
+	delay = (ms_left - (frametime + 2));
+
+	if (delay < 1) {
+		notify_output_frame(output);
+	} else {
+		wl_event_source_timer_update(output->state.frame_timer, delay);
+	}
+}
+
+static void
+notify_output_pre_frame(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.pre_frame);
+	struct tw_output_device *device = output->output->device;
+
+	clock_gettime(device->clk_id, &output->state.ts);
+	PROFILE_BEG("notify_output_repaint");
+}
+
+static void
+notify_output_post_frame(struct wl_listener *listener, void *data)
+{
+	struct timespec now;
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.post_frame);
+	struct tw_output_device *device = output->output->device;
+	struct tw_render_output *render_output =
+		wl_container_of(device, render_output, device);
+
+	clock_gettime(device->clk_id, &now);
+	update_output_frame_time(output, &output->state.ts, &now);
+	tw_render_output_flush_frame(render_output, &now);
+	PROFILE_END("notify_output_repaint");
+}
+
+static void
+notify_output_present(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.present);
+	struct tw_event_output_present *event = data;
+
+	output->state.last_present = event->time;
+	SCOPE_PROFILE_TS();
+}
+
+static void
+notify_output_clock_reset(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.clock_reset);
+	output->state.ft_idx = 0;
+	memset(output->state.fts, 0, sizeof(output->state.fts));
+}
+
+static void
+notify_output_destroy(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.destroy);
+
+        tw_server_output_fini(output);
+	//this basically on output lost
+}
+
+/******************************************************************************
+ * constructor/destructor
+ *****************************************************************************/
+
+static void
+tw_server_output_fini(struct tw_server_output *output)
+{
+	wl_event_source_remove(output->state.frame_timer);
+	output->state.frame_timer = NULL;
+	output->output = NULL;
+
+	tw_reset_wl_list(&output->listeners.destroy.link);
+	tw_reset_wl_list(&output->listeners.need_frame.link);
+	tw_reset_wl_list(&output->listeners.pre_frame.link);
+	tw_reset_wl_list(&output->listeners.post_frame.link);
+	tw_reset_wl_list(&output->listeners.present.link);
+}
+
+static void
+tw_server_output_init(struct tw_server_output *output,
+                      struct tw_engine_output *engine_output,
+                      struct tw_render_context *ctx)
+{
+	struct tw_output_device *device = engine_output->device;
+	struct tw_render_output *render_output =
+		wl_container_of(device, render_output, device);
+	struct wl_display *display = engine_output->engine->display;
+	struct wl_event_loop *loop = wl_display_get_event_loop(display);
+
+        output->output = engine_output;
+        output->state.frame_timer =
+	        wl_event_loop_add_timer(loop, notify_output_frame, output);
+
+        tw_signal_setup_listener(&render_output->signals.need_frame,
+                                 &output->listeners.need_frame,
+                                 notify_output_reshedule_frame);
+        tw_signal_setup_listener(&render_output->signals.pre_frame,
+                                 &output->listeners.pre_frame,
+                                 notify_output_pre_frame);
+        tw_signal_setup_listener(&render_output->signals.post_frame,
+                                 &output->listeners.post_frame,
+                                 notify_output_post_frame);
+        tw_signal_setup_listener(&render_output->signals.present,
+                                 &output->listeners.present,
+                                 notify_output_present);
+        //device signals
+        tw_signal_setup_listener(&device->signals.clock_reset,
+                                 &output->listeners.clock_reset,
+                                 notify_output_clock_reset);
+        tw_signal_setup_listener(&device->signals.destroy,
+                                 &output->listeners.destroy,
+                                 notify_output_destroy);
+}
+
+/******************************************************************************
+ * manager listeners
+ *****************************************************************************/
+
+static void
+notify_mgr_tw_surface_dirty(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output_manager *mgr =
+		wl_container_of(listener, mgr, listeners.surface_dirty);
+	struct tw_surface *surface = data;
+	struct tw_render_surface *render_surface =
+		wl_container_of(surface, render_surface, surface);
+	struct tw_render_context *ctx = mgr->ctx;
+	struct tw_render_output *output;
+
+	if (pixman_region32_not_empty(&surface->geometry.dirty))
+		reassign_surface_outputs(render_surface, ctx, mgr->engine);
+
+	wl_list_for_each(output, &ctx->outputs, link) {
+		if ((1u << output->device.id) & render_surface->output_mask)
+			tw_render_output_dirty(output);
+	}
+}
+
+static void
+notify_mgr_tw_surface_lost(struct wl_listener *listener, void *data)
+{
+	//TODO just dirty the output regards the surface damage.
+}
+
+static void
+notify_mgr_new_output(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output_manager *mgr =
+		wl_container_of(listener, mgr, listeners.new_output);
+	struct tw_engine_output *output = data;
+	unsigned id = output->device->id;
+
+	tw_server_output_init(&mgr->outputs[id], output, mgr->ctx);
+}
+
+static void
+notify_mgr_render_context_lost(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output_manager *mgr =
+		wl_container_of(listener, mgr, listeners.context_destroy);
+
+        mgr->ctx = NULL;
+	mgr->engine = NULL;
+
+	tw_reset_wl_list(&mgr->listeners.context_destroy.link);
+	tw_reset_wl_list(&mgr->listeners.surface_dirty.link);
+	tw_reset_wl_list(&mgr->listeners.surface_lost.link);
+	tw_reset_wl_list(&mgr->listeners.new_output.link);
+}
+
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx)
+{
+	static struct tw_server_output_manager mgr = {0};
+
+	mgr.engine = engine;
+	mgr.ctx = ctx;
+
+	tw_signal_setup_listener(&engine->signals.output_created,
+	                         &mgr.listeners.new_output,
+	                         notify_mgr_new_output);
+	tw_signal_setup_listener(&ctx->signals.wl_surface_dirty,
+	                         &mgr.listeners.surface_dirty,
+	                         notify_mgr_tw_surface_dirty);
+	tw_signal_setup_listener(&ctx->signals.wl_surface_destroy,
+	                         &mgr.listeners.surface_lost,
+	                         notify_mgr_tw_surface_lost);
+	tw_signal_setup_listener(&ctx->signals.destroy,
+	                         &mgr.listeners.context_destroy,
+	                         notify_mgr_render_context_lost);
+	return &mgr;
+}

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -1,0 +1,88 @@
+/*
+ * output.h - taiwins server output headers
+ *
+ * Copyright (c) 2021 Xichen Zhou
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef TAIWINS_OUTPUT_H
+#define TAIWINS_OUTPUT_H
+
+#include <time.h>
+#include <wayland-server-core.h>
+#include <wayland-server.h>
+#include <taiwins/engine.h>
+#include <taiwins/render_context.h>
+#include <taiwins/objects/compositor.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#define TW_FRAME_TIME_CNT 8
+
+//we shall see how this works
+struct tw_server_output {
+	struct tw_engine_output *output;
+
+	struct {
+		/** average frame time in microseconds */
+		uint32_t fts[TW_FRAME_TIME_CNT], ft_idx;
+		struct timespec ts; /** used for recording start of frame */
+		struct timespec last_present;
+		struct wl_event_source *frame_timer;
+	} state;
+
+	struct {
+		/**< device signals */
+		struct wl_listener destroy;
+                struct wl_listener present;
+		struct wl_listener clock_reset;
+		/**< render_output signals */
+		struct wl_listener need_frame;
+		struct wl_listener pre_frame;
+		struct wl_listener post_frame;
+	} listeners;
+};
+
+struct tw_server_output_manager {
+
+	struct tw_engine *engine;
+	struct tw_render_context *ctx;
+
+	//reflect to the engine
+	struct tw_server_output outputs[32];
+
+	struct {
+		struct wl_listener context_destroy;
+		struct wl_listener surface_dirty;
+		struct wl_listener surface_lost;
+		struct wl_listener new_output;
+	} listeners;
+
+};
+
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
+
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* EOF */

--- a/include/taiwins/engine.h
+++ b/include/taiwins/engine.h
@@ -76,8 +76,6 @@ struct tw_engine_output {
 		struct wl_listener set_mode;
 		struct wl_listener destroy;
 		struct wl_listener present;
-		struct wl_listener surface_enter;
-		struct wl_listener surface_leave;
 	} listeners;
 };
 
@@ -171,6 +169,13 @@ tw_engine_output_from_resource(struct tw_engine *engine,
 struct tw_engine_output *
 tw_engine_output_from_device(struct tw_engine *engine,
                              const struct tw_output_device *device);
+void
+tw_engine_output_notify_surface_enter(struct tw_engine_output *output,
+                                      struct tw_surface *surface);
+void
+tw_engine_output_notify_surface_leave(struct tw_engine_output *output,
+                                      struct tw_surface *surface);
+
 
 #ifdef  __cplusplus
 }

--- a/include/taiwins/objects/profiler.h
+++ b/include/taiwins/objects/profiler.h
@@ -41,6 +41,9 @@ tw_profiler_start_timer(const char *name);
 void
 tw_profiler_stop_timer(const char *name);
 
+void
+tw_profiler_timestamp(const char *name);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/include/taiwins/objects/surface.h
+++ b/include/taiwins/objects/surface.h
@@ -47,9 +47,9 @@ enum tw_surface_state {
 	TW_SURFACE_BUFFER_SCALED = (1 << 4),
 	TW_SURFACE_OPAQUE_REGION = (1 << 5),
 	TW_SURFACE_INPUT_REGION = (1 << 6),
-	/** frame is released in frame, not in commit. If surface never has any
-	 * thinng to commit, we should not care about frame. */
-	//TW_SURFACE_FRAME_REQUESTED = (1 << 9),
+	/* clients may requested a frame but has no buffer to commit,
+	 * essentially they just want a callback_done */
+	TW_SURFACE_FRAME_REQUESTED = (1 << 9),
 };
 
 struct tw_surface;

--- a/include/taiwins/objects/utils.h
+++ b/include/taiwins/objects/utils.h
@@ -23,6 +23,7 @@
 #define TW_SIGNAL_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
 #include <wayland-server-core.h>
@@ -116,6 +117,8 @@ extern const struct tw_allocator tw_default_allocator;
 		ret; \
 	})
 
+#define TW_NS_PER_S 1000000000
+
 static inline uint32_t
 tw_millihertz_to_ns(unsigned mHz)
 {
@@ -124,20 +127,46 @@ tw_millihertz_to_ns(unsigned mHz)
 }
 
 static inline uint64_t
-tw_timespec_to_msec(const struct timespec *spec)
+tw_timespec_to_ms(const struct timespec *spec)
 {
-	return (int64_t)spec->tv_sec * 1000 + spec->tv_nsec / 1000000;
+	return (uint64_t)spec->tv_sec * 1000 + spec->tv_nsec / 1000000;
+}
+
+static inline uint64_t
+tw_timespec_to_us(const struct timespec *spec)
+{
+	return (uint64_t)spec->tv_sec * 1000000 + spec->tv_nsec / 1000;
 }
 
 static inline uint32_t
-tw_get_time_msec(clockid_t clk)
+tw_get_time_ms(clockid_t clk)
 {
 	struct timespec now;
 
 	clock_gettime(clk, &now);
-	return tw_timespec_to_msec(&now);
+	return tw_timespec_to_ms(&now);
 }
 
+static inline long
+tw_timespec_diff_ns(const struct timespec *a, const struct timespec *b)
+{
+	return (a->tv_sec - b->tv_sec) * (long)TW_NS_PER_S +
+		(a->tv_nsec - b->tv_nsec);
+}
+
+static inline long
+tw_timespec_diff_us(const struct timespec *a, const struct timespec *b)
+{
+	return ((a->tv_sec - b->tv_sec) * (long)1000000) +
+		((a->tv_nsec - b->tv_nsec) / 1000);
+}
+
+static inline int
+tw_timespec_diff_ms(const struct timespec *a, const struct timespec *b)
+{
+	return ((a->tv_sec - b->tv_sec) * 1000) +
+		((a->tv_nsec - b->tv_nsec) / 1000000);
+}
 
 #ifdef  __cplusplus
 }

--- a/include/taiwins/output_device.h
+++ b/include/taiwins/output_device.h
@@ -91,7 +91,7 @@ struct tw_output_device {
 	struct wl_list link; /** backend: list */
 	struct wl_list mode_list;
 
-	struct tw_output_device_state state, pending;
+	struct tw_output_device_state current, pending;
 
 	struct {
 		struct wl_signal destroy;
@@ -139,9 +139,9 @@ static inline void
 tw_output_device_set_current_mode(struct tw_output_device *device,
                                   unsigned width, unsigned height, int refresh)
 {
-		device->state.current_mode.h = height;
-		device->state.current_mode.w = width;
-		device->state.current_mode.refresh = refresh;
+		device->current.current_mode.h = height;
+		device->current.current_mode.w = width;
+		device->current.current_mode.refresh = refresh;
 		wl_signal_emit(&device->signals.commit_state, device);
 		wl_signal_emit(&device->signals.info, device);
 }

--- a/include/taiwins/output_device.h
+++ b/include/taiwins/output_device.h
@@ -92,6 +92,7 @@ struct tw_output_device {
 	struct wl_list mode_list;
 
 	struct tw_output_device_state current, pending;
+	struct timespec last_present;
 
 	struct {
 		struct wl_signal destroy;

--- a/include/taiwins/profiling.h
+++ b/include/taiwins/profiling.h
@@ -34,12 +34,16 @@ extern "C" {
 
 #define SCOPE_PROFILE_BEG() tw_profiler_start_timer(__func__)
 #define SCOPE_PROFILE_END() tw_profiler_stop_timer(__func__)
+#define PROFILE_BEG(name) tw_profiler_start_timer(name)
+#define PROFILE_END(name) tw_profiler_stop_timer(name)
 #define SCOPE_PROFILE_TS() tw_profiler_timestamp(__func__)
 
 #else
 
 #define SCOPE_PROFILE_BEG()
 #define SCOPE_PROFILE_END()
+#define PROFILE_BEG(name)
+#define PROFILE_END(name)
 #define SCOPE_PROFILE_TS()
 #endif
 

--- a/include/taiwins/profiling.h
+++ b/include/taiwins/profiling.h
@@ -34,12 +34,13 @@ extern "C" {
 
 #define SCOPE_PROFILE_BEG() tw_profiler_start_timer(__func__)
 #define SCOPE_PROFILE_END() tw_profiler_stop_timer(__func__)
+#define SCOPE_PROFILE_TS() tw_profiler_timestamp(__func__)
 
 #else
 
 #define SCOPE_PROFILE_BEG()
 #define SCOPE_PROFILE_END()
-
+#define SCOPE_PROFILE_TS()
 #endif
 
 #ifdef  __cplusplus

--- a/include/taiwins/render_context.h
+++ b/include/taiwins/render_context.h
@@ -129,9 +129,6 @@ void
 tw_render_context_build_view_list(struct tw_render_context *ctx,
                                   struct tw_layers_manager *manager);
 void
-tw_render_surface_reassign_outputs(struct tw_render_surface *render_surface,
-                                   struct tw_render_context *ctx);
-void
 tw_render_context_set_dma(struct tw_render_context *ctx,
                           struct tw_linux_dmabuf *dma);
 void

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -108,6 +108,9 @@ void
 tw_render_output_dirty(struct tw_render_output *output);
 
 void
+tw_render_output_schedule_frame(struct tw_render_output *output);
+
+void
 tw_render_output_commit(struct tw_render_output *output);
 
 void

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -65,9 +65,9 @@ struct tw_render_output {
 
 		uint32_t repaint_state;
                 /** average frame time is ft_sum / ft_cnt */
-		unsigned long ft_sum, ft_cnt;
+		unsigned long ft_sum;
 		/** average frame time in microseconds */
-		unsigned int fts[TW_FRAME_TIME_CNT], ft_idx;
+		unsigned int fts[TW_FRAME_TIME_CNT], ft_idx, ft_cnt;
 		/** additional checks for running render_output */
 	} state;
 

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -52,6 +52,7 @@ struct tw_render_output {
 
 	struct wl_list link; /**< ctx->output */
 	struct wl_list views;
+	struct wl_event_source *repaint_timer;
 	/* important to set it for surface to be renderable */
 	struct tw_render_context *ctx;
 
@@ -71,12 +72,13 @@ struct tw_render_output {
 	} state;
 
 	struct {
-		struct wl_listener frame;
-		struct wl_listener set_mode;
-		struct wl_listener destroy;
-		struct wl_listener surface_dirty;
+		struct wl_listener frame; /* device::new_frame */
+		struct wl_listener set_mode; /* device::set_mode */
+		struct wl_listener destroy; /* device::destroy */
+		struct wl_listener surface_dirty; /* context::surface_dirty */
 	} listeners;
 
+	/* TODO: maybe move this to engine_output? */
 	struct {
 		struct wl_signal surface_enter;
 		struct wl_signal surface_leave;
@@ -85,7 +87,8 @@ struct tw_render_output {
 
 void
 tw_render_output_init(struct tw_render_output *output,
-                      const struct tw_output_device_impl *impl);
+                      const struct tw_output_device_impl *impl,
+                      struct wl_display *display);
 void
 tw_render_output_fini(struct tw_render_output *output);
 

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -35,7 +35,7 @@
 extern "C" {
 #endif
 
-#define TW_FRAME_TIME_CNT 10
+#define TW_FRAME_TIME_CNT 8
 
 struct tw_render_context;
 
@@ -64,10 +64,8 @@ struct tw_render_output {
 		struct tw_mat3 view_2d; /* global to output space */
 
 		uint32_t repaint_state;
-                /** average frame time is ft_sum / ft_cnt */
-		unsigned long ft_sum;
 		/** average frame time in microseconds */
-		unsigned int fts[TW_FRAME_TIME_CNT], ft_idx, ft_cnt;
+		uint32_t fts[TW_FRAME_TIME_CNT], ft_idx;
 		/** additional checks for running render_output */
 	} state;
 
@@ -94,9 +92,6 @@ tw_render_output_fini(struct tw_render_output *output);
 
 void
 tw_render_output_reset_clock(struct tw_render_output *output, clockid_t clk);
-
-uint32_t
-tw_render_output_calc_frametime(struct tw_render_output *output);
 
 void
 tw_render_output_set_context(struct tw_render_output *output,

--- a/libtaiwins/backend/drm/display.c
+++ b/libtaiwins/backend/drm/display.c
@@ -279,9 +279,9 @@ handle_display_commit_state(struct tw_output_device *device)
 
 	select_display_mode(output);
 	UPDATE_PENDING(output, active, enabled, TW_DRM_PENDING_ACTIVE);
-	memcpy(&device->state, &device->pending, sizeof(device->state));
+	memcpy(&device->current, &device->pending, sizeof(device->current));
 	//we cannot use output_device_enable hear because it sets the pending
-	device->state.enabled = enabled;
+	device->current.enabled = enabled;
 
 	tw_drm_display_check_action(output, NULL);
 	return true;

--- a/libtaiwins/backend/drm/display.c
+++ b/libtaiwins/backend/drm/display.c
@@ -472,7 +472,8 @@ tw_drm_display_find_create(struct tw_drm_gpu *gpu, drmModeConnector *conn,
 			return NULL;
 		dpy->drm = drm;
 		dpy->gpu = gpu;
-		tw_render_output_init(&dpy->output, &output_dev_impl);
+		tw_render_output_init(&dpy->output, &output_dev_impl,
+		                      drm->display);
 		read_display_info(dpy, conn);
 
 		wl_list_init(&dpy->presentable_commit.link);

--- a/libtaiwins/backend/drm/drm.c
+++ b/libtaiwins/backend/drm/drm.c
@@ -191,11 +191,11 @@ handle_page_flip2(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec,
                   unsigned crtc_id, void *data)
 {
 	struct tw_drm_display *output = data;
-	struct tw_output_device *device = output ?
-		&output->output.device : NULL;
+	struct tw_render_output *render_output = output ?
+		&output->output : NULL;
 
-	struct tw_event_output_device_present present = {
-		.device = device,
+	struct tw_event_output_present present = {
+		.output = render_output,
 		.time = {
 			.tv_sec = tv_sec,
 			.tv_nsec = tv_usec * 1000,
@@ -207,7 +207,7 @@ handle_page_flip2(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec,
 	if (output) {
                 assert(output->gpu->gpu_fd == fd);
 		tw_drm_display_handle_page_flipped(output, crtc_id);
-                tw_output_device_present(device, &present);
+                tw_render_output_present(render_output, &present);
 	}
 }
 

--- a/libtaiwins/backend/headless.c
+++ b/libtaiwins/backend/headless.c
@@ -165,7 +165,7 @@ headless_commit_output_state(struct tw_output_device *device)
 	assert(device->pending.scale >= 1.0);
 	assert(device->pending.current_mode.h > 0 &&
 	       device->pending.current_mode.w > 0);
-	memcpy(&device->state, &device->pending, sizeof(device->state));
+	memcpy(&device->current, &device->pending, sizeof(device->current));
 	return true;
 }
 

--- a/libtaiwins/backend/headless.c
+++ b/libtaiwins/backend/headless.c
@@ -80,7 +80,7 @@ headless_frame(void *data)
 {
 	struct tw_headless_output *output = data;
 
-	wl_signal_emit(&output->output.device.signals.new_frame,
+	wl_signal_emit(&output->output.signals.need_frame,
 	               &output->output.device);
 	wl_event_source_timer_update(output->timer, 1000000 / (60 * 1000));
 	return 0;
@@ -91,7 +91,7 @@ notify_output_commit(struct wl_listener *listener, void *data)
 {
 	struct tw_headless_output *output =
 		wl_container_of(listener, output, present_listener);
-	tw_output_device_present(&output->output.device, NULL);
+	tw_render_output_present(&output->output, NULL);
 	tw_render_output_clean_maybe(&output->output);
 }
 

--- a/libtaiwins/backend/headless.c
+++ b/libtaiwins/backend/headless.c
@@ -251,7 +251,8 @@ tw_headless_backend_add_output(struct tw_backend *backend,
 		return false;
 	}
         device = &output->output.device;
-        tw_render_output_init(&output->output, &headless_output_impl);
+        tw_render_output_init(&output->output, &headless_output_impl,
+                              headless->display);
 
         tw_output_device_set_custom_mode(&output->output.device,
                                          width, height, 0);

--- a/libtaiwins/backend/wayland/backend.c
+++ b/libtaiwins/backend/wayland/backend.c
@@ -180,7 +180,7 @@ handle_presentation_clock_id(void *data,
 	wl->clk_id = clk_id;
 
 	wl_list_for_each(surface, &wl->base.outputs, output.device.link)
-		tw_render_output_reset_clock(&surface->output, clk_id);
+		tw_output_device_reset_clock(&surface->output.device, clk_id);
 }
 
 static const struct wp_presentation_listener presentation_listener = {

--- a/libtaiwins/backend/wayland/output.c
+++ b/libtaiwins/backend/wayland/output.c
@@ -51,7 +51,7 @@ check_pending_stop(struct tw_output_device *output)
 		wl_container_of(output, wl_surface, output.device);
 
 	bool penable = output->pending.enabled;
-	bool cenable = output->state.enabled;
+	bool cenable = output->current.enabled;
 
 	if (wl_surface->egl_window && cenable && !penable) {
 		tw_logl_level(TW_LOG_WARN, "changing wl_output@%s enabling "
@@ -68,7 +68,7 @@ handle_commit_output_state(struct tw_output_device *output)
 	struct tw_wl_surface *wl_surface =
 		wl_container_of(output, wl_surface, output.device);
 	unsigned width, height;
-	bool enabled = output->pending.enabled || output->state.enabled;
+	bool enabled = output->pending.enabled || output->current.enabled;
 
 	if (!check_pending_stop(output))
 		return false;
@@ -77,10 +77,10 @@ handle_commit_output_state(struct tw_output_device *output)
 	assert(output->pending.current_mode.h > 0 &&
 	       output->pending.current_mode.w > 0);
 
-        memcpy(&output->state, &output->pending, sizeof(output->state));
+        memcpy(&output->current, &output->pending, sizeof(output->current));
         //override the enabling and refresh rate
-        output->state.enabled = enabled;
-        output->state.current_mode.refresh = wl_surface->residing ?
+        output->current.enabled = enabled;
+        output->current.current_mode.refresh = wl_surface->residing ?
 	        (int)wl_surface->residing->r : -1;
 
         //resize, maybe getting output to start?

--- a/libtaiwins/backend/wayland/output.c
+++ b/libtaiwins/backend/wayland/output.c
@@ -195,15 +195,15 @@ handle_feedback_presented(void *data,
 		.tv_sec = ((uint64_t)tv_sec_hi << 32) | tv_sec_lo,
 		.tv_nsec = tv_nsec,
 	};
-	struct tw_event_output_device_present event = {
-		.device = &output->output.device,
+	struct tw_event_output_present event = {
+		.output = &output->output,
 		.time = time,
 		.seq = ((uint64_t)seq_hi << 32) | seq_lo,
 		.refresh = refresh,
 		.flags = flags,
 	};
 
-	tw_output_device_present(&output->output.device, &event);
+	tw_render_output_present(&output->output, &event);
 	wp_presentation_feedback_destroy(wp_feedback);
 }
 
@@ -212,7 +212,7 @@ handle_feedback_discarded(void *data,
                           struct wp_presentation_feedback *wp_feedback)
 {
 	struct tw_wl_surface *output = data;
-	tw_output_device_present(&output->output.device, NULL);
+	tw_render_output_present(&output->output, NULL);
 	wp_presentation_feedback_destroy(wp_feedback);
 }
 
@@ -332,7 +332,7 @@ notify_output_commit(struct wl_listener *listener, void *data)
 		                                      &feedback_listener,
 		                                      output);
 	else
-		tw_output_device_present(&output->output.device, NULL);
+		tw_render_output_present(&output->output, NULL);
 	tw_render_output_clean_maybe(&output->output);
 }
 
@@ -427,7 +427,7 @@ tw_wl_backend_new_output(struct tw_backend *backend,
 	output->wl = wl;
 	tw_render_output_init(&output->output, &output_impl,
 	                      wl->server_display);
-	tw_render_output_reset_clock(&output->output, wl->clk_id);
+	tw_output_device_reset_clock(&output->output.device, wl->clk_id);
         tw_output_device_set_custom_mode(&output->output.device, width, height,
                                          0);
 

--- a/libtaiwins/backend/wayland/output.c
+++ b/libtaiwins/backend/wayland/output.c
@@ -425,7 +425,8 @@ tw_wl_backend_new_output(struct tw_backend *backend,
         }
 
 	output->wl = wl;
-	tw_render_output_init(&output->output, &output_impl);
+	tw_render_output_init(&output->output, &output_impl,
+	                      wl->server_display);
 	tw_render_output_reset_clock(&output->output, wl->clk_id);
         tw_output_device_set_custom_mode(&output->output.device, width, height,
                                          0);

--- a/libtaiwins/backend/wayland/seat.c
+++ b/libtaiwins/backend/wayland/seat.c
@@ -59,7 +59,7 @@ handle_keyboard_enter(void *data, struct wl_keyboard *wl_keyboard,
 {
 	struct tw_wl_seat *seat = wl_keyboard_get_user_data(wl_keyboard);
 	struct tw_input_device *keyboard = &seat->keyboard_dev;
-	uint32_t time = tw_get_time_msec(seat->wl->clk_id);
+	uint32_t time = tw_get_time_ms(seat->wl->clk_id);
 	uint32_t *keycode;
 
 	wl_array_for_each(keycode, keys) {

--- a/libtaiwins/backend/x11/backend.c
+++ b/libtaiwins/backend/x11/backend.c
@@ -58,25 +58,11 @@ handle_x11_configure_notify(struct tw_output_device *device,
 		                                  refresh);
 }
 
-static void
-handle_new_x11_frame(void *data)
-{
-	struct tw_x11_output *output = data;
-
-	wl_signal_emit(&output->output.device.signals.new_frame,
-	               &output->output.device);
-}
-
-static void
+static inline void
 handle_x11_request_frame(struct tw_x11_backend *x11,
                          struct tw_x11_output *output)
 {
-	struct wl_display *display = x11->display;
-	struct wl_event_loop *loop = wl_display_get_event_loop(display);
-
-	if (!loop)
-	        return;
-        wl_event_loop_add_idle(loop, handle_new_x11_frame, output);
+	tw_render_output_dirty(&output->output);
 }
 
 static int

--- a/libtaiwins/backend/x11/backend.c
+++ b/libtaiwins/backend/x11/backend.c
@@ -52,7 +52,7 @@ static void
 handle_x11_configure_notify(struct tw_output_device *device,
                             xcb_configure_notify_event_t *ev)
 {
-	int refresh = device->state.current_mode.refresh;
+	int refresh = device->current.current_mode.refresh;
 	if (ev->width > 0 && ev->height > 0)
 		tw_output_device_set_current_mode(device, ev->width, ev->height,
 		                                  refresh);

--- a/libtaiwins/backend/x11/output.c
+++ b/libtaiwins/backend/x11/output.c
@@ -69,16 +69,16 @@ handle_commit_output_state(struct tw_output_device *output)
 {
 	struct tw_x11_output *x11_output =
 		wl_container_of(output, x11_output, output.device);
-	bool enabled = output->pending.enabled || output->state.enabled;
+	bool enabled = output->pending.enabled || output->current.enabled;
 	struct tw_output_device_state pending = output->pending;
-	bool resize = !tw_output_device_mode_eq(&output->state.current_mode,
+	bool resize = !tw_output_device_mode_eq(&output->current.current_mode,
 	                                        &output->pending.current_mode);
 
 	pending.current_mode.refresh = DEFAULT_REFRESH;
 	pending.enabled = enabled;
 	if (!check_pending_stop(output))
 		return false;
-	if (tw_output_device_state_eq(&output->state, &pending))
+	if (tw_output_device_state_eq(&output->current, &pending))
 		return false;
 
 	assert(pending.scale >= 1.0);
@@ -86,7 +86,7 @@ handle_commit_output_state(struct tw_output_device *output)
 
 	//the x11 backend will simply resize the output for us so we only need
 	//to update the view matrix
-	memcpy(&output->state, &pending, sizeof(output->state));
+	memcpy(&output->current, &pending, sizeof(output->current));
 
 	if (x11_output->win == XCB_WINDOW_NONE && enabled)
 		tw_x11_output_start(x11_output);

--- a/libtaiwins/backend/x11/output.c
+++ b/libtaiwins/backend/x11/output.c
@@ -262,7 +262,7 @@ tw_x11_backend_add_output(struct tw_backend *backend,
 		return false;
         output->x11 = x11;
 
-        tw_render_output_init(&output->output, &x11_output_impl);
+        tw_render_output_init(&output->output, &x11_output_impl, x11->display);
         tw_output_device_set_custom_mode(&output->output.device, width, height,
                                          0);
 

--- a/libtaiwins/engine/output.c
+++ b/libtaiwins/engine/output.c
@@ -109,22 +109,22 @@ notify_output_info(struct wl_listener *listener, void *data)
 	struct tw_engine_output *output =
 		wl_container_of(listener, output, listeners.info);
 	tw_output_set_name(output->tw_output, output->device->name);
-	tw_output_set_scale(output->tw_output, output->device->state.scale);
-	tw_output_set_coord(output->tw_output, output->device->state.gx,
-	                    output->device->state.gy);
+	tw_output_set_scale(output->tw_output, output->device->current.scale);
+	tw_output_set_coord(output->tw_output, output->device->current.gx,
+	                    output->device->current.gy);
 	tw_output_set_mode(output->tw_output, WL_OUTPUT_MODE_CURRENT |
-	                   ((output->device->state.current_mode.preferred) ?
+	                   ((output->device->current.current_mode.preferred) ?
 	                    WL_OUTPUT_MODE_PREFERRED : 0),
-	                   output->device->state.current_mode.w,
-	                   output->device->state.current_mode.h,
-	                   output->device->state.current_mode.refresh);
+	                   output->device->current.current_mode.w,
+	                   output->device->current.current_mode.h,
+	                   output->device->current.current_mode.refresh);
 	tw_output_set_geometry(output->tw_output,
 	                       output->device->phys_width,
 	                       output->device->phys_height,
 	                       output->device->make,
 	                       output->device->model,
 	                       output->device->subpixel,
-	                       output->device->state.transform);
+	                       output->device->current.transform);
 	tw_output_send_clients(output->tw_output);
 }
 

--- a/libtaiwins/engine/output.c
+++ b/libtaiwins/engine/output.c
@@ -94,8 +94,6 @@ notify_output_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&output->listeners.info.link);
 	wl_list_remove(&output->listeners.present.link);
 	wl_list_remove(&output->listeners.set_mode.link);
-	wl_list_remove(&output->listeners.surface_enter.link);
-	wl_list_remove(&output->listeners.surface_leave.link);
 
 	tw_output_destroy(output->tw_output);
 
@@ -148,7 +146,7 @@ notify_output_present(struct wl_listener *listener, void *data)
 	struct tw_engine_output *output =
 		wl_container_of(listener, output, listeners.present);
 	struct tw_engine *engine = output->engine;
-	struct tw_event_output_device_present *event = data;
+	struct tw_event_output_present *event = data;
 
 	wl_list_for_each_safe(feedback, tmp, &engine->presentation.feedbacks,
 	                      link) {
@@ -165,32 +163,6 @@ notify_output_present(struct wl_listener *listener, void *data)
 			                             event->flags);
 		else
 			tw_presentation_feedback_discard(feedback);
-	}
-}
-
-static void
-notify_output_surface_enter(struct wl_listener *listener, void *data)
-{
-	struct wl_resource *wl_output;
-	struct tw_surface *surface = data;
-	struct tw_engine_output *output =
-		wl_container_of(listener, output, listeners.surface_enter);
-	wl_resource_for_each(wl_output, &output->tw_output->resources) {
-		if (tw_match_wl_resource_client(wl_output, surface->resource))
-			wl_surface_send_enter(surface->resource, wl_output);
-	}
-}
-
-static void
-notify_output_surface_leave(struct wl_listener *listener, void *data)
-{
-	struct wl_resource *wl_output;
-	struct tw_surface *surface = data;
-	struct tw_engine_output *output =
-		wl_container_of(listener, output, listeners.surface_leave);
-	wl_resource_for_each(wl_output, &output->tw_output->resources) {
-		if (tw_match_wl_resource_client(wl_output, surface->resource))
-			wl_surface_send_leave(surface->resource, wl_output);
 	}
 }
 
@@ -234,15 +206,9 @@ tw_engine_new_output(struct tw_engine *engine,
 	tw_signal_setup_listener(&device->signals.commit_state,
 	                         &output->listeners.set_mode,
 	                         notify_output_new_mode);
-	tw_signal_setup_listener(&device->signals.present,
+	tw_signal_setup_listener(&render_output->signals.present,
 	                         &output->listeners.present,
 	                         notify_output_present);
-	tw_signal_setup_listener(&render_output->signals.surface_enter,
-	                         &output->listeners.surface_enter,
-	                         notify_output_surface_enter);
-	tw_signal_setup_listener(&render_output->signals.surface_leave,
-	                         &output->listeners.surface_leave,
-	                         notify_output_surface_leave);
         engine->output_pool |= 1 << id;
         wl_list_init(&output->link);
         wl_list_insert(&engine->heads, &output->link);
@@ -323,4 +289,28 @@ tw_engine_output_from_device(struct tw_engine *engine,
 			return output;
 	//this may not be a good idea?
 	return tw_engine_get_focused_output(engine);
+}
+
+WL_EXPORT void
+tw_engine_output_notify_surface_enter(struct tw_engine_output *output,
+                                      struct tw_surface *surface)
+{
+	struct wl_resource *wl_output;
+
+	wl_resource_for_each(wl_output, &output->tw_output->resources) {
+		if (tw_match_wl_resource_client(wl_output, surface->resource))
+			wl_surface_send_enter(surface->resource, wl_output);
+	}
+}
+
+WL_EXPORT void
+tw_engine_output_notify_surface_leave(struct tw_engine_output *output,
+                                      struct tw_surface *surface)
+{
+	struct wl_resource *wl_output;
+
+	wl_resource_for_each(wl_output, &output->tw_output->resources) {
+		if (tw_match_wl_resource_client(wl_output, surface->resource))
+			wl_surface_send_leave(surface->resource, wl_output);
+	}
 }

--- a/libtaiwins/objects/profiler.c
+++ b/libtaiwins/objects/profiler.c
@@ -178,3 +178,10 @@ tw_profiler_stop_timer(const char *name)
 	write_end(scope, s_profiler.file, !s_profiler.empty);
 	s_profiler.empty = false;
 }
+
+WL_EXPORT void
+tw_profiler_timestamp(const char *name)
+{
+	tw_profiler_start_timer(name);
+	tw_profiler_stop_timer(name);
+}

--- a/libtaiwins/output_device.c
+++ b/libtaiwins/output_device.c
@@ -207,6 +207,7 @@ tw_output_device_present(struct tw_output_device *device,
 		clock_gettime(device->clk_id, &now);
 		event->time = now;
 	}
+	device->last_present = event->time;
 	event->refresh = tw_millihertz_to_ns(mhz);
 	wl_signal_emit(&device->signals.present, event);
 }

--- a/libtaiwins/output_device.c
+++ b/libtaiwins/output_device.c
@@ -19,6 +19,7 @@
  *
  */
 
+#include "options.h"
 #include <math.h>
 #include <stdint.h>
 #include <time.h>
@@ -30,6 +31,7 @@
 #include <taiwins/objects/logger.h>
 #include <taiwins/output_device.h>
 #include <taiwins/objects/utils.h>
+#include <taiwins/profiling.h>
 #include <wayland-util.h>
 
 static void
@@ -207,6 +209,7 @@ tw_output_device_present(struct tw_output_device *device,
 		clock_gettime(device->clk_id, &now);
 		event->time = now;
 	}
+	SCOPE_PROFILE_TS();
 	device->last_present = event->time;
 	event->refresh = tw_millihertz_to_ns(mhz);
 	wl_signal_emit(&device->signals.present, event);

--- a/libtaiwins/output_device.c
+++ b/libtaiwins/output_device.c
@@ -74,10 +74,8 @@ tw_output_device_init(struct tw_output_device *device,
 
 	wl_signal_init(&device->signals.destroy);
 	wl_signal_init(&device->signals.info);
-	wl_signal_init(&device->signals.new_frame);
-	wl_signal_init(&device->signals.info);
-	wl_signal_init(&device->signals.present);
 	wl_signal_init(&device->signals.commit_state);
+	wl_signal_init(&device->signals.clock_reset);
 }
 
 WL_EXPORT void
@@ -193,26 +191,6 @@ tw_output_device_commit_state(struct tw_output_device *device)
 		//emit for sending new backend info.
 		wl_signal_emit(&device->signals.info, device);
 	}
-}
-
-WL_EXPORT void
-tw_output_device_present(struct tw_output_device *device,
-                         struct tw_event_output_device_present *event)
-{
-	uint32_t mhz = device->current.current_mode.refresh;
-	struct tw_event_output_device_present _event = {
-		.device = device,
-	};
-	struct timespec now;
-	if (event == NULL) {
-		event = &_event;
-		clock_gettime(device->clk_id, &now);
-		event->time = now;
-	}
-	SCOPE_PROFILE_TS();
-	device->last_present = event->time;
-	event->refresh = tw_millihertz_to_ns(mhz);
-	wl_signal_emit(&device->signals.present, event);
 }
 
 static void

--- a/libtaiwins/output_device.c
+++ b/libtaiwins/output_device.c
@@ -67,7 +67,7 @@ tw_output_device_init(struct tw_output_device *device,
 	wl_list_init(&device->mode_list);
 	wl_list_init(&device->link);
 
-	output_device_state_init(&device->state, device);
+	output_device_state_init(&device->current, device);
 	output_device_state_init(&device->pending, device);
 
 	wl_signal_init(&device->signals.destroy);
@@ -197,7 +197,7 @@ WL_EXPORT void
 tw_output_device_present(struct tw_output_device *device,
                          struct tw_event_output_device_present *event)
 {
-	uint32_t mhz = device->state.current_mode.refresh;
+	uint32_t mhz = device->current.current_mode.refresh;
 	struct tw_event_output_device_present _event = {
 		.device = device,
 	};
@@ -231,9 +231,9 @@ tw_output_device_geometry(const struct tw_output_device *output)
 {
 	int width, height;
 
-	output_get_effective_resolution(&output->state, &width, &height);
+	output_get_effective_resolution(&output->current, &width, &height);
 	return (pixman_rectangle32_t){
-		output->state.gx, output->state.gy,
+		output->current.gx, output->current.gy,
 		width, height
 	};
 }
@@ -244,18 +244,18 @@ tw_output_device_loc_to_global(const struct tw_output_device *output,
 {
 	int width, height;
 
-	output_get_effective_resolution(&output->state, &width, &height);
+	output_get_effective_resolution(&output->current, &width, &height);
 
-	*gx = output->state.gx + x * width;
-	*gy = output->state.gy + y * height;
+	*gx = output->current.gx + x * width;
+	*gy = output->current.gy + y * height;
 }
 
 WL_EXPORT void
 tw_output_device_raw_resolution(const struct tw_output_device *device,
                                 unsigned *width, unsigned *height)
 {
-	*width = device->state.current_mode.w;
-	*height = device->state.current_mode.h;
+	*width = device->current.current_mode.w;
+	*height = device->current.current_mode.h;
 }
 
 WL_EXPORT bool

--- a/libtaiwins/render/render_context.c
+++ b/libtaiwins/render/render_context.c
@@ -62,7 +62,7 @@ notify_tw_surface_output_lost(struct wl_listener *listener, void *data)
 {
 	struct tw_render_surface *surface =
 		wl_container_of(listener, surface, listeners.output_lost);
-	tw_render_surface_reassign_outputs(surface, surface->ctx);
+	tw_surface_dirty_geometry(&surface->surface);
 }
 
 static void
@@ -285,73 +285,6 @@ tw_render_context_build_view_list(struct tw_render_context *ctx,
 	SCOPE_PROFILE_END();
 }
 
-static void
-update_surface_mask(struct tw_surface *base, struct tw_render_context *ctx,
-                    struct tw_render_output *major, uint32_t mask)
-{
-	struct tw_render_output *output;
-	struct tw_render_surface *surface =
-		wl_container_of(base, surface, surface);
-	uint32_t output_bit;
-	uint32_t different = surface->output_mask ^ mask;
-	uint32_t entered = mask & different;
-	uint32_t left = surface->output_mask & different;
-
-	//update the surface_mask and
-	surface->output_mask = mask;
-	surface->output = major ? major->device.id : -1;
-
-	wl_list_for_each(output, &ctx->outputs, link) {
-		output_bit = 1u << output->device.id;
-		if (!(output_bit & different))
-			continue;
-		if ((output_bit & entered))
-			wl_signal_emit(&output->signals.surface_enter, base);
-		if ((output_bit & left))
-			wl_signal_emit(&output->signals.surface_leave, base);
-	}
-}
-
-WL_EXPORT void
-tw_render_surface_reassign_outputs(struct tw_render_surface *render_surface,
-                                   struct tw_render_context *ctx)
-{
-	uint32_t area = 0, max = 0, mask = 0;
-	struct tw_render_output *output, *major = NULL;
-	pixman_region32_t surface_region;
-	pixman_box32_t *e;
-	struct tw_surface *surface = &render_surface->surface;
-
-	pixman_region32_init_rect(&surface_region,
-	                          surface->geometry.xywh.x,
-	                          surface->geometry.xywh.y,
-	                          surface->geometry.xywh.width,
-	                          surface->geometry.xywh.height);
-	wl_list_for_each(output, &ctx->outputs, link) {
-		pixman_region32_t clip;
-		struct tw_output_device *device = &output->device;
-		pixman_rectangle32_t rect =
-			tw_output_device_geometry(device);
-		//TODO dealing with cloning output
-		// if (output->cloning >= 0)
-		//	continue;
-		pixman_region32_init_rect(&clip, rect.x, rect.y,
-		                          rect.width, rect.height);
-		pixman_region32_intersect(&clip, &clip, &surface_region);
-		e = pixman_region32_extents(&clip);
-		area = (e->x2 - e->x1) * (e->y2 - e->y1);
-		if (pixman_region32_not_empty(&clip))
-			mask |= (1u << device->id);
-		if (area >= max) {
-			major = output;
-			max = area;
-		}
-		pixman_region32_fini(&clip);
-	}
-	pixman_region32_fini(&surface_region);
-
-	update_surface_mask(surface, ctx, major, mask);
-}
 
 WL_EXPORT void
 tw_render_context_set_compositor(struct tw_render_context *ctx,

--- a/libtaiwins/render/render_output.c
+++ b/libtaiwins/render/render_output.c
@@ -174,7 +174,7 @@ notify_render_output_frame(void *data)
 	uint32_t should_repaint = TW_REPAINT_DIRTY | TW_REPAINT_SCHEDULED;
 
 	assert(ctx);
-	if (!output->device.state.enabled)
+	if (!output->device.current.enabled)
 		return 0;
 	if (!check_bits(output->state.repaint_state, should_repaint))
 		return 0;
@@ -207,7 +207,7 @@ notify_render_output_frame_scheduled(struct wl_listener *listener, void *data)
 		wl_container_of(listener, output, listeners.frame);
 
 	assert(&output->device == data);
-	if (!output->device.state.enabled)
+	if (!output->device.current.enabled)
 		return;
 	notify_render_output_frame(output);
 }
@@ -290,7 +290,7 @@ tw_render_output_rebuild_view_mat(struct tw_render_output *output)
 {
 	struct tw_mat3 glproj, tmp;
 	int width, height;
-	const struct tw_output_device_state *state = &output->device.state;
+	const struct tw_output_device_state *state = &output->device.current;
 	pixman_rectangle32_t rect = tw_output_device_geometry(&output->device);
 
 	//the transform should be
@@ -375,7 +375,7 @@ tw_render_output_schedule_frame(struct tw_render_output *output)
 	struct wl_event_loop *loop = wl_display_get_event_loop(display);
 
 	if (!(output->state.repaint_state & TW_REPAINT_SCHEDULED) &&
-	    output->device.state.enabled) {
+	    output->device.current.enabled) {
 		wl_event_loop_add_idle(loop, output_idle_frame, output);
 		output->state.repaint_state |= TW_REPAINT_SCHEDULED;
 	}

--- a/libtaiwins/render/render_output.c
+++ b/libtaiwins/render/render_output.c
@@ -19,7 +19,6 @@
  *
  */
 
-#include "options.h"
 #include <assert.h>
 #include <time.h>
 #include <pixman.h>
@@ -34,7 +33,6 @@
 #include <taiwins/render_output.h>
 #include <taiwins/render_surface.h>
 #include <taiwins/render_pipeline.h>
-#include <taiwins/profiling.h>
 #include <ctypes/helpers.h>
 
 static inline bool
@@ -77,261 +75,8 @@ fini_output_state(struct tw_render_output *o)
 		pixman_region32_fini(&o->state.damages[i]);
 }
 
-/**
- * @brief manage the backend output damage state
- */
-static inline void
-shuffle_output_damage(struct tw_render_output *output)
-{
-	//here we swap the damage as if it is output is triple-buffered. It is
-	//okay even if output is actually double buffered, as we only need to
-	//ensure that renderer requested the correct damage based on the age.
-	pixman_region32_t *curr = output->state.curr_damage;
-	pixman_region32_t *pending = output->state.pending_damage;
-	pixman_region32_t *previous = output->state.prev_damage;
-
-	//later on renderer will access either current or previous damage for
-	//composing buffer_damage.
-	output->state.curr_damage = pending;
-	output->state.prev_damage = curr;
-	output->state.pending_damage = previous;
-}
-
 static void
-output_idle_frame(void *data)
-{
-	struct tw_render_output *output = data;
-	//TODO we should reset clock here
-	wl_signal_emit(&output->device.signals.new_frame, &output->device);
-}
-
-/*
- * update the frame time for the output.
- */
-static void
-update_output_frame_time(struct tw_render_output *output,
-                         const struct timespec *strt,
-                         const struct timespec *end)
-{
-	uint32_t ft;
-	uint64_t tstart = tw_timespec_to_us(strt);
-	uint64_t tend = tw_timespec_to_us(end);
-
-	/* assert(tend >= tstart); */
-	ft = MAX((uint32_t)0, (uint32_t)(tend - tstart));
-	output->state.fts[output->state.ft_idx] = ft;
-	output->state.ft_idx = (output->state.ft_idx + 1) % TW_FRAME_TIME_CNT;
-}
-
-/* getting the max frame time in milliseconds */
-static uint32_t
-calc_output_max_frametime(struct tw_render_output *output)
-{
-	uint32_t *fts = output->state.fts;
-	uint32_t ft = MAX(MAX(MAX(fts[0], fts[1]), MAX(fts[2],fts[3])),
-	                  MAX(MAX(fts[4], fts[5]), MAX(fts[6],fts[7])));
-	//ceil algorithm, output basically
-	return ft ? ((ft + 1000) / 1000) : ft;
-}
-
-static void
-flush_output_frame(struct tw_render_output *output,
-                   const struct timespec *now)
-{
-	struct tw_surface *surface;
-	uint32_t now_int = tw_timespec_to_ms(now);
-
-	wl_list_for_each(surface, &output->views, links[TW_VIEW_OUTPUT_LINK])
-		tw_surface_flush_frame(surface, now_int);
-}
-
-/******************************************************************************
- * listeners
- *****************************************************************************/
-
-static void
-notify_render_output_surface_dirty(struct wl_listener *listener, void *data)
-{
-	struct tw_render_output *output =
-		wl_container_of(listener, output, listeners.surface_dirty);
-	struct tw_surface *surface = data;
-	struct tw_render_surface *render_surface =
-		wl_container_of(surface, render_surface, surface);
-	struct tw_render_context *ctx = output->ctx;
-
-        assert(ctx);
-	if (pixman_region32_not_empty(&surface->geometry.dirty))
-		tw_render_surface_reassign_outputs(render_surface, ctx);
-
-	wl_list_for_each(output, &ctx->outputs, link) {
-		if ((1u << output->device.id) & render_surface->output_mask)
-			tw_render_output_dirty(output);
-	}
-}
-
-static int
-notify_render_output_frame(void *data)
-{
-	struct tw_render_output *output = data;
-	struct tw_render_presentable *presentable = &output->surface;
-	struct tw_render_context *ctx = output->ctx;
-	struct tw_render_pipeline *pipeline;
-	struct timespec tstart, tend;
-	int buffer_age;
-	uint32_t should_repaint = TW_REPAINT_DIRTY | TW_REPAINT_SCHEDULED;
-
-	assert(ctx);
-	if (!output->device.current.enabled)
-		return 0;
-	if (!check_bits(output->state.repaint_state, should_repaint))
-		return 0;
-	if (check_bits(output->state.repaint_state, TW_REPAINT_COMMITTED))
-		return 0;
-
-	SCOPE_PROFILE_BEG();
-	clock_gettime(output->device.clk_id, &tstart);
-
-	buffer_age = tw_render_presentable_make_current(presentable, ctx);
-	buffer_age = (buffer_age < 0) ? 2 : buffer_age;
-
-	wl_list_for_each(pipeline, &ctx->pipelines, link)
-		tw_render_pipeline_repaint(pipeline, output, buffer_age);
-
-	shuffle_output_damage(output);
-
-	tw_render_output_commit(output);
-	clock_gettime(output->device.clk_id, &tend);
-	update_output_frame_time(output, &tstart, &tend);
-	flush_output_frame(output, &tend);
-	SCOPE_PROFILE_END();
-	return 0;
-}
-
-static void
-notify_render_output_frame_scheduled(struct wl_listener *listener, void *data)
-{
-	int delay, ms_left = 0; //< left for render
-	struct tw_render_output *output =
-		wl_container_of(listener, output, listeners.frame);
-	//TODO: change it to max frame time
-	int frametime = calc_output_max_frametime(output);
-
-	assert(&output->device == data);
-	if (!output->device.current.enabled)
-		return;
-
-	if (frametime) { //becomes max_render_time
-		struct timespec now;
-		//get current time as soon as possible
-		clock_gettime(output->device.clk_id, &now);
-
-		struct timespec predict_refresh = output->device.last_present;
-		unsigned mhz = output->device.current.current_mode.refresh;
-		uint32_t refresh = tw_millihertz_to_ns(mhz);
-
-		//getting a predicted vblank. 1): If we are scheduled right
-		//after a vsync, there are chance predict_refresh is ahead of
-		//us. 2) If we come from a idle frame, predict_time will be
-		//less than now, in that case, we just draw
-
-		predict_refresh.tv_nsec += refresh % TW_NS_PER_S;
-		predict_refresh.tv_sec += refresh / TW_NS_PER_S;
-		if (predict_refresh.tv_nsec >= TW_NS_PER_S) {
-			predict_refresh.tv_sec += 1;
-			predict_refresh.tv_nsec -= TW_NS_PER_S;
-		}
-
-		//this is the floored difference.
-		if (predict_refresh.tv_sec >= now.tv_sec)
-			ms_left = tw_timespec_diff_ms(&predict_refresh, &now);
-	}
-	//here we added 2 extra ms frametime, it seems with amount, we are
-	//able to catch up with next vblank. TODO we can we not rely on this,
-	//otherwise we would have to move this repaint logic out of libtaiwins.
-	delay = (ms_left - (frametime + 2));
-
-	if (delay < 1) {
-		notify_render_output_frame(output);
-	} else {
-		wl_event_source_timer_update(output->repaint_timer, delay);
-	}
-}
-
-static void
-notify_render_output_destroy(struct wl_listener *listener, void *data)
-{
-	struct tw_render_output *output =
-		wl_container_of(listener, output, listeners.destroy);
-	tw_render_output_fini(output);
-}
-
-static void
-notify_render_output_new_mode(struct wl_listener *listener, void *data)
-{
-	struct tw_render_output *output =
-		wl_container_of(listener, output, listeners.set_mode);
-	tw_render_output_rebuild_view_mat(output);
-}
-
-/******************************************************************************
- * APIs
- *****************************************************************************/
-
-WL_EXPORT void
-tw_render_output_init(struct tw_render_output *output,
-                      const struct tw_output_device_impl *impl,
-                      struct wl_display *display)
-{
-	output->ctx = NULL;
-	output->surface.impl = NULL;
-	output->surface.handle = 0;
-	init_output_state(output);
-	//this cannot fail
-	output->repaint_timer = wl_event_loop_add_timer(
-		wl_display_get_event_loop(display),
-		notify_render_output_frame, output);
-
-	tw_output_device_init(&output->device, impl);
-	tw_render_output_reset_clock(output, CLOCK_MONOTONIC);
-
-	wl_list_init(&output->link);
-
-	wl_signal_init(&output->surface.commit);
-	wl_signal_init(&output->signals.surface_enter);
-	wl_signal_init(&output->signals.surface_leave);
-
-	wl_list_init(&output->listeners.surface_dirty.link);
-	tw_signal_setup_listener(&output->device.signals.new_frame,
-	                         &output->listeners.frame,
-	                         notify_render_output_frame_scheduled);
-	tw_signal_setup_listener(&output->device.signals.destroy,
-	                         &output->listeners.destroy,
-	                         notify_render_output_destroy);
-	tw_signal_setup_listener(&output->device.signals.commit_state,
-	                         &output->listeners.set_mode,
-	                         notify_render_output_new_mode);
-}
-
-WL_EXPORT void
-tw_render_output_fini(struct tw_render_output *output)
-{
-	fini_output_state(output);
-	wl_list_remove(&output->listeners.destroy.link);
-	wl_list_remove(&output->listeners.frame.link);
-	wl_list_remove(&output->listeners.set_mode.link);
-	wl_list_remove(&output->listeners.surface_dirty.link);
-
-	if (output->ctx && output->surface.impl)
-		tw_render_presentable_fini(&output->surface, output->ctx);
-	if (output->repaint_timer) {
-		wl_event_source_remove(output->repaint_timer);
-		output->repaint_timer = NULL;
-	}
-	tw_output_device_fini(&output->device);
-}
-
-WL_EXPORT void
-tw_render_output_rebuild_view_mat(struct tw_render_output *output)
+rebuild_render_output_view_mat(struct tw_render_output *output)
 {
 	struct tw_mat3 glproj, tmp;
 	int width, height;
@@ -359,6 +104,127 @@ tw_render_output_rebuild_view_mat(struct tw_render_output *output)
 	                 &output->state.view_2d);
 }
 
+/**
+ * @brief manage the backend output damage state
+ */
+static inline void
+shuffle_output_damage(struct tw_render_output *output)
+{
+	//here we swap the damage as if it is output is triple-buffered. It is
+	//okay even if output is actually double buffered, as we only need to
+	//ensure that renderer requested the correct damage based on the age.
+	pixman_region32_t *curr = output->state.curr_damage;
+	pixman_region32_t *pending = output->state.pending_damage;
+	pixman_region32_t *previous = output->state.prev_damage;
+
+	//later on renderer will access either current or previous damage for
+	//composing buffer_damage.
+	output->state.curr_damage = pending;
+	output->state.prev_damage = curr;
+	output->state.pending_damage = previous;
+}
+
+/*
+ * after commit, the output should not dirty anymore, but the schedule state
+ * should not change, it shield us from committing another frame before the
+ * pageflip/swapbuffer happens.
+*/
+static inline void
+commit_render_output(struct tw_render_output *output)
+{
+	output->state.repaint_state = TW_REPAINT_COMMITTED;
+	tw_render_presentable_commit(&output->surface, output->ctx);
+}
+
+static int
+tick_render_output_frame(struct tw_render_output *output)
+{
+	struct tw_render_presentable *presentable = &output->surface;
+	struct tw_render_context *ctx = output->ctx;
+	struct tw_render_pipeline *pipeline;
+	int buffer_age;
+
+	assert(ctx);
+	buffer_age = tw_render_presentable_make_current(presentable, ctx);
+	buffer_age = (buffer_age < 0) ? 2 : buffer_age;
+
+	wl_list_for_each(pipeline, &ctx->pipelines, link)
+		tw_render_pipeline_repaint(pipeline, output, buffer_age);
+
+	shuffle_output_damage(output);
+	commit_render_output(output);
+	return 0;
+}
+
+/******************************************************************************
+ * listeners
+ *****************************************************************************/
+
+static void
+notify_render_output_destroy(struct wl_listener *listener, void *data)
+{
+	struct tw_render_output *output =
+		wl_container_of(listener, output, listeners.destroy);
+	tw_render_output_fini(output);
+}
+
+static void
+notify_render_output_new_mode(struct wl_listener *listener, void *data)
+{
+	struct tw_render_output *output =
+		wl_container_of(listener, output, listeners.set_mode);
+	rebuild_render_output_view_mat(output);
+}
+
+/******************************************************************************
+ * APIs
+ *****************************************************************************/
+
+WL_EXPORT void
+tw_render_output_init(struct tw_render_output *output,
+                      const struct tw_output_device_impl *impl,
+                      struct wl_display *display)
+{
+	output->ctx = NULL;
+	output->surface.impl = NULL;
+	output->surface.handle = 0;
+	init_output_state(output);
+
+	tw_output_device_init(&output->device, impl);
+	tw_output_device_reset_clock(&output->device, CLOCK_MONOTONIC);
+
+	wl_list_init(&output->link);
+
+	wl_signal_init(&output->surface.commit);
+	wl_signal_init(&output->signals.need_frame);
+	wl_signal_init(&output->signals.pre_frame);
+	wl_signal_init(&output->signals.post_frame);
+	wl_signal_init(&output->signals.present);
+
+	tw_signal_setup_listener(&output->device.signals.destroy,
+	                         &output->listeners.destroy,
+	                         notify_render_output_destroy);
+	tw_signal_setup_listener(&output->device.signals.commit_state,
+	                         &output->listeners.set_mode,
+	                         notify_render_output_new_mode);
+}
+
+WL_EXPORT void
+tw_render_output_fini(struct tw_render_output *output)
+{
+	fini_output_state(output);
+	wl_list_remove(&output->listeners.destroy.link);
+	wl_list_remove(&output->listeners.set_mode.link);
+
+	if (output->ctx && output->surface.impl)
+		tw_render_presentable_fini(&output->surface, output->ctx);
+	if (output->repaint_timer) {
+		wl_event_source_remove(output->repaint_timer);
+		output->repaint_timer = NULL;
+	}
+	tw_output_device_fini(&output->device);
+}
+
 WL_EXPORT void
 tw_render_output_set_context(struct tw_render_output *output,
                              struct tw_render_context *ctx)
@@ -369,11 +235,6 @@ tw_render_output_set_context(struct tw_render_output *output,
 	output->ctx = ctx;
 	tw_reset_wl_list(&output->link);
 	wl_list_insert(ctx->outputs.prev, &output->link);
-
-	tw_reset_wl_list(&output->listeners.surface_dirty.link);
-	tw_signal_setup_listener(&ctx->signals.wl_surface_dirty,
-	                         &output->listeners.surface_dirty,
-	                         notify_render_output_surface_dirty);
 }
 
 WL_EXPORT void
@@ -384,49 +245,45 @@ tw_render_output_unset_context(struct tw_render_output *output)
 	assert(!output->surface.handle);
 	output->ctx = NULL;
 	tw_reset_wl_list(&output->link);
-	tw_reset_wl_list(&output->listeners.surface_dirty.link);
 	wl_signal_emit(&ctx->signals.output_lost, output);
 }
 
 WL_EXPORT void
-tw_render_output_reset_clock(struct tw_render_output *output, clockid_t clk)
+tw_render_output_flush_frame(struct tw_render_output *output,
+                             const struct timespec *now)
 {
-	output->device.clk_id = clk;
-	output->state.ft_idx = 0;
-	memset(output->state.fts, 0, sizeof(output->state.fts));
+	struct tw_surface *surface;
+	uint32_t now_int = tw_timespec_to_ms(now);
+
+	wl_list_for_each(surface, &output->views, links[TW_VIEW_OUTPUT_LINK])
+		tw_surface_flush_frame(surface, now_int);
 }
 
 WL_EXPORT void
 tw_render_output_dirty(struct tw_render_output *output)
 {
 	output->state.repaint_state |= TW_REPAINT_DIRTY;
-	tw_render_output_schedule_frame(output);
-}
-
-/* schedule a frame, maybe for the purpose sending back empty frame_request */
-WL_EXPORT void
-tw_render_output_schedule_frame(struct tw_render_output *output)
-{
-	struct wl_display *display = output->ctx->display;
-	struct wl_event_loop *loop = wl_display_get_event_loop(display);
-
 	if (!(output->state.repaint_state & TW_REPAINT_SCHEDULED) &&
-	    output->device.current.enabled) {
-		wl_event_loop_add_idle(loop, output_idle_frame, output);
-		output->state.repaint_state |= TW_REPAINT_SCHEDULED;
-	}
+	    output->device.current.enabled)
+		wl_signal_emit(&output->signals.need_frame, output);
 }
 
-/*
- * after commit, the output should not dirty anymore, but the schedule state
- * should not change, it shield us from committing another frame before the
- * pageflip/swapbuffer happens.
-*/
 WL_EXPORT void
-tw_render_output_commit(struct tw_render_output *output)
+tw_render_output_post_frame(struct tw_render_output *output)
 {
-	output->state.repaint_state = TW_REPAINT_COMMITTED;
-	tw_render_presentable_commit(&output->surface, output->ctx);
+	if (!output->device.current.enabled)
+		return;
+	if (!(output->state.repaint_state & TW_REPAINT_DIRTY))
+		return;
+	if ((output->state.repaint_state & TW_REPAINT_SCHEDULED))
+		return;
+	if (check_bits(output->state.repaint_state, TW_REPAINT_COMMITTED))
+		return;
+
+	output->state.repaint_state |= TW_REPAINT_SCHEDULED;
+	wl_signal_emit(&output->signals.pre_frame, output);
+	tick_render_output_frame(output);
+	wl_signal_emit(&output->signals.post_frame, output);
 }
 
 /*
@@ -440,4 +297,23 @@ tw_render_output_clean_maybe(struct tw_render_output *output)
 	output->state.repaint_state &= ~TW_REPAINT_COMMITTED;
 	if (output->state.repaint_state & TW_REPAINT_DIRTY)
 		tw_render_output_dirty(output);
+}
+
+void
+tw_render_output_present(struct tw_render_output *output,
+                         struct tw_event_output_present *event)
+{
+	struct tw_output_device *dev = &output->device;
+	uint32_t mhz = dev->current.current_mode.refresh;
+	struct tw_event_output_present _event = {
+		.output = output,
+	};
+	struct timespec now;
+	if (event == NULL) {
+		event = &_event;
+		clock_gettime(dev->clk_id, &now);
+		event->time = now;
+	}
+	event->refresh = tw_millihertz_to_ns(mhz);
+	wl_signal_emit(&output->signals.present, event);
 }

--- a/libtaiwins/shell/shell.c
+++ b/libtaiwins/shell/shell.c
@@ -445,7 +445,7 @@ shell_send_output_config(struct tw_shell *shell,
                          enum taiwins_shell_output_msg msg)
 {
 	pixman_rectangle32_t geo = tw_output_device_geometry(output->device);
-	int scale = output->device->state.scale;
+	int scale = output->device->current.scale;
 
 	if (shell->shell_resource)
 		taiwins_shell_send_output_configure(shell->shell_resource,

--- a/test/drm-test.c
+++ b/test/drm-test.c
@@ -20,6 +20,9 @@
 struct tw_render_pipeline *
 tw_egl_render_pipeline_create_default(struct tw_render_context *ctx,
                                       struct tw_layers_manager *manager);
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
 static inline void
 wait_for_debug()
 {
@@ -140,6 +143,8 @@ int main(int argc, char *argv[])
 	wl_list_insert(ctx->pipelines.next, &pipeline->link);
 
 	wait_for_debug();
+
+        tw_server_output_manager_create_global(engine, ctx);
 
 	tw_backend_start(backend, ctx);
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -71,7 +71,7 @@ test('test_headless', headless_test)
 if get_option('x11-backend').enabled()
   x11_test = executable(
     'tw-test-x11',
-    ['x11-test.c', '../compositor/egl_renderer.c', 'test_desktop.c',
+    ['x11-test.c', '../compositor/egl_renderer.c', '../compositor/output.c', 'test_desktop.c',
      wayland_taiwins_shell_server_protocol_h],
     c_args : debug_cargs,
     dependencies : dep_taiwins_lib,
@@ -82,7 +82,7 @@ endif
 
 wayland_test = executable(
   'tw-test-wayland',
-  ['wayland-test.c', '../compositor/egl_renderer.c', 'test_desktop.c',
+  ['wayland-test.c', '../compositor/egl_renderer.c', '../compositor/output.c', 'test_desktop.c',
    wayland_taiwins_shell_server_protocol_h],
   c_args : debug_cargs,
   dependencies : dep_taiwins_lib,
@@ -91,7 +91,7 @@ test('test_wayland', wayland_test)
 
 drm_test = executable(
   'tw-test-drm',
-  ['drm-test.c', '../compositor/egl_renderer.c', 'test_desktop.c' ],
+  ['drm-test.c', '../compositor/egl_renderer.c', '../compositor/output.c', 'test_desktop.c' ],
   c_args : debug_cargs,
   dependencies : dep_taiwins_lib,
 )

--- a/test/wayland-test.c
+++ b/test/wayland-test.c
@@ -19,6 +19,9 @@
 struct tw_render_pipeline *
 tw_egl_render_pipeline_create_default(struct tw_render_context *ctx,
                                       struct tw_layers_manager *manager);
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
 static void
 set_dirty(void *data)
 {
@@ -98,7 +101,7 @@ int main(int argc, char *argv[])
 		tw_egl_render_pipeline_create_default(ctx,
 		                                      &engine->layers_manager);
 	wl_list_insert(ctx->pipelines.next, &pipeline->link);
-
+        tw_server_output_manager_create_global(engine, ctx);
 	tw_backend_start(backend, ctx);
 
 	wl_display_run(display);

--- a/test/x11-test.c
+++ b/test/x11-test.c
@@ -36,6 +36,10 @@ struct data {
 struct tw_render_pipeline *
 tw_egl_render_pipeline_create_default(struct tw_render_context *ctx,
                                       struct tw_layers_manager *manager);
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
+
 #ifdef _TW_HAS_XWAYLAND
 static void
 notify_xserver_ready(struct wl_listener *listener, void *data)
@@ -154,6 +158,8 @@ int main(int argc, char *argv[])
                                  &data.listeners.seat_focused,
                                  notify_xserver_seat_focused);
 #endif
+
+        tw_server_output_manager_create_global(engine, ctx);
 
 	tw_backend_start(backend, ctx);
 


### PR DESCRIPTION
This is done before by weston and sway. We basically need to do the same thing here.

At the moment, we just use a idle frame call, whenever a client damaged the surface and committed, an idle frame is **scheduled** for rendering next frame. Once the render starts, **scheduling** is effectively blocked until next page-flip.

This effectively is a double-frame architecture, (if we were to change it to Triple-buffer, we would basically need to ask `aquireNextImage` for scheduling a frame draw, and release an image on pageflip. But anyway, that's future work).

Anyway, this architecture has advantage that we don't draw unnecessary frames. But it draws too fast. We should draw only draw frames closes to pageflip so user receives better frame.done event.

This means we need to add a delay, between `tw_render_output_schedule_frame` and actual output renders.