### PR TITLE
login: don't kill wl_display on session_removed.

### DIFF
--- a/libtaiwins/backend/drm/login/logind.c
+++ b/libtaiwins/backend/drm/login/logind.c
@@ -171,10 +171,7 @@ out:
 static int
 logind_bus_handle_session_removed(const struct tdbus_signal *signal)
 {
-	struct tw_logind_login *logind = signal->user_data;
-
 	tw_logl("logind Session removed !");
-	wl_display_terminate(logind->display);
 	return 0;
 }
 


### PR DESCRIPTION
After Display manager(gdm) launch taiwins it will remove its session,
effectively sends a session_removed signal. We do not kill ourseleves on this.

Need read though the logind documents though. The direct login is probably
broke as well.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>