### PR TITLE
render: rendering scheduling split

### DIFF
--- a/compositor/main.c
+++ b/compositor/main.c
@@ -29,6 +29,7 @@
 #include <getopt.h>
 #include <sys/wait.h>
 #include <limits.h>
+#include <wayland-server-core.h>
 #include <wayland-server.h>
 #include <taiwins/objects/logger.h>
 #include <taiwins/objects/profiler.h>
@@ -47,6 +48,7 @@
 #include <taiwins/render_pipeline.h>
 
 #include "input.h"
+#include "output.h"
 #include "render.h"
 #include "desktop/xdg.h"
 #include "config/config.h"
@@ -67,9 +69,10 @@ struct tw_server {
 	struct tw_backend *backend;
 	struct tw_engine *engine;
 	struct tw_render_context *ctx;
-	struct tw_config config;
+        struct tw_config config;
+	struct tw_server_output_manager *output_manager;
 
-	/* seats */
+        /* seats */
 	struct tw_seat_listeners seat_listeners[8];
 	struct wl_listener seat_add;
 	struct wl_listener seat_remove;
@@ -127,6 +130,9 @@ notify_removing_seat(struct wl_listener *listener, void *data)
 static void
 bind_listeners(struct tw_server *server)
 {
+	server->output_manager =
+		tw_server_output_manager_create_global(server->engine,
+		                                       server->ctx);
 	tw_signal_setup_listener(&server->engine->signals.seat_created,
 	                         &server->seat_add,
 	                         notify_adding_seat);

--- a/compositor/main.c
+++ b/compositor/main.c
@@ -29,7 +29,6 @@
 #include <getopt.h>
 #include <sys/wait.h>
 #include <limits.h>
-#include <wayland-server-core.h>
 #include <wayland-server.h>
 #include <taiwins/objects/logger.h>
 #include <taiwins/objects/profiler.h>

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -14,6 +14,7 @@ endif
 taiwins_src = [
   'main.c',
   'input.c',
+  'output.c',
   'bindings.c',
   'egl_renderer.c',
 

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -6,6 +6,10 @@ elif get_option('rendering-debug') == 'clip'
   taiwins_cargs += '-D_TW_DEBUG_CLIP'
 endif
 
+if get_option('enable-profiler')
+  taiwins_cargs += '-D_TW_ENABLE_PROFILING'
+endif
+
 if get_option('xwayland').enabled()
   taiwins_cargs += '-D_TW_HAS_XWAYLAND'
 endif

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -1,0 +1,398 @@
+/*
+ * output.c - taiwins server output implementation
+ *
+ * Copyright (c) 2021 Xichen Zhou
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <pixman.h>
+#include <wayland-server-core.h>
+#include <wayland-server.h>
+#include <taiwins/objects/utils.h>
+#include <taiwins/engine.h>
+#include <taiwins/backend.h>
+#include <taiwins/render_output.h>
+#include <taiwins/render_context.h>
+#include <taiwins/render_surface.h>
+#include <ctypes/helpers.h>
+#include <wayland-util.h>
+
+#include "output.h"
+#include "taiwins/objects/surface.h"
+
+static void
+tw_server_output_fini(struct tw_server_output *output);
+
+static inline void
+update_output_frame_time(struct tw_server_output *output,
+                         const struct timespec *strt,
+                         const struct timespec *end)
+{
+	uint32_t ft;
+	uint64_t tstart = tw_timespec_to_us(strt);
+	uint64_t tend = tw_timespec_to_us(end);
+
+	/* assert(tend >= tstart); */
+	ft = MAX((uint32_t)0, (uint32_t)(tend - tstart));
+	output->state.fts[output->state.ft_idx] = ft;
+	output->state.ft_idx = (output->state.ft_idx + 1) % TW_FRAME_TIME_CNT;
+}
+
+/* getting the max frame time in milliseconds */
+static inline uint32_t
+calc_output_max_frametime(struct tw_server_output *output)
+{
+	uint32_t *fts = output->state.fts;
+	uint32_t ft = MAX(MAX(MAX(fts[0], fts[1]), MAX(fts[2],fts[3])),
+	                  MAX(MAX(fts[4], fts[5]), MAX(fts[6],fts[7])));
+	//ceil algorithm, output basically
+	return ft ? ((ft + 1000) / 1000) : ft;
+}
+
+/******************************************************************************
+ * surface output relations
+ *****************************************************************************/
+
+static void
+update_surface_mask(struct tw_surface *base, struct tw_render_context *ctx,
+                    struct tw_render_output *major, uint32_t mask)
+{
+	struct tw_render_output *output;
+	struct tw_render_surface *surface =
+		wl_container_of(base, surface, surface);
+	uint32_t output_bit;
+	uint32_t different = surface->output_mask ^ mask;
+	uint32_t entered = mask & different;
+	uint32_t left = surface->output_mask & different;
+
+	//update the surface_mask and
+	surface->output_mask = mask;
+	surface->output = major ? major->device.id : -1;
+
+	wl_list_for_each(output, &ctx->outputs, link) {
+		output_bit = 1u << output->device.id;
+		if (!(output_bit & different))
+			continue;
+		if ((output_bit & entered))
+			wl_signal_emit(&output->signals.surface_enter, base);
+		if ((output_bit & left))
+			wl_signal_emit(&output->signals.surface_leave, base);
+	}
+}
+
+/* we employ the same logic for surface output assigning in weston, compares
+ * the surface 2D geometry against the output
+ */
+static void
+reassign_surface_outputs(struct tw_render_surface *render_surface,
+                         struct tw_render_context *ctx)
+{
+	uint32_t area = 0, max = 0, mask = 0;
+	struct tw_render_output *output, *major = NULL;
+	pixman_region32_t surface_region;
+	pixman_box32_t *e;
+	struct tw_surface *surface = &render_surface->surface;
+
+	pixman_region32_init_rect(&surface_region,
+	                          surface->geometry.xywh.x,
+	                          surface->geometry.xywh.y,
+	                          surface->geometry.xywh.width,
+	                          surface->geometry.xywh.height);
+	wl_list_for_each(output, &ctx->outputs, link) {
+		pixman_region32_t clip;
+		struct tw_output_device *device = &output->device;
+		pixman_rectangle32_t rect =
+			tw_output_device_geometry(device);
+		//TODO dealing with cloning output
+		// if (output->cloning >= 0)
+		//	continue;
+		pixman_region32_init_rect(&clip, rect.x, rect.y,
+		                          rect.width, rect.height);
+		pixman_region32_intersect(&clip, &clip, &surface_region);
+		e = pixman_region32_extents(&clip);
+		area = (e->x2 - e->x1) * (e->y2 - e->y1);
+		if (pixman_region32_not_empty(&clip))
+			mask |= (1u << device->id);
+		if (area >= max) {
+			major = output;
+			max = area;
+		}
+		pixman_region32_fini(&clip);
+	}
+	pixman_region32_fini(&surface_region);
+
+	update_surface_mask(surface, ctx, major, mask);
+}
+
+/******************************************************************************
+ * output listeners
+ *****************************************************************************/
+
+static int
+notify_output_frame(void *data)
+{
+	struct tw_server_output *output = data;
+	struct tw_render_output *render_output =
+		wl_container_of(output->output->device, render_output, device);
+	tw_render_output_post_frame(render_output);
+	return 0;
+}
+
+static void
+notify_output_reshedule_frame(struct wl_listener *listener, void *data)
+{
+	int delay, ms_left = 0; //< left for render
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.need_frame);
+	struct tw_output_device *device = data;
+
+	int frametime = calc_output_max_frametime(output);
+
+	assert(output->output->device == device);
+	if (!device->current.enabled)
+		return;
+
+	if (frametime) { //becomes max_render_time
+		struct timespec now;
+		//get current time as soon as possible
+		clock_gettime(device->clk_id, &now);
+
+		struct timespec predict_refresh = output->state.last_present;
+		unsigned mhz = device->current.current_mode.refresh;
+		uint32_t refresh = tw_millihertz_to_ns(mhz);
+
+		//getting a predicted vblank. 1): If we are scheduled right
+		//after a vsync, there are chance predict_refresh is ahead of
+		//us. 2) If we come from a idle frame, predict_time will be
+		//less than now, in that case, we just draw
+
+		predict_refresh.tv_nsec += refresh % TW_NS_PER_S;
+		predict_refresh.tv_sec += refresh / TW_NS_PER_S;
+		if (predict_refresh.tv_nsec >= TW_NS_PER_S) {
+			predict_refresh.tv_sec += 1;
+			predict_refresh.tv_nsec -= TW_NS_PER_S;
+		}
+
+		//this is the floored difference.
+		if (predict_refresh.tv_sec >= now.tv_sec)
+			ms_left = tw_timespec_diff_ms(&predict_refresh, &now);
+	}
+	//here we added 2 extra ms frametime, it seems with amount, we are
+	//able to catch up with next vblank. TODO we can we not rely on this,
+	//otherwise we would have to move this repaint logic out of libtaiwins.
+	delay = (ms_left - (frametime + 2));
+
+	if (delay < 1) {
+		notify_output_frame(output);
+	} else {
+		wl_event_source_timer_update(output->state.frame_timer, delay);
+	}
+}
+
+static void
+notify_output_pre_frame(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.pre_frame);
+	struct tw_output_device *device = output->output->device;
+
+	clock_gettime(device->clk_id, &output->state.ts);
+	//TODO add profiler
+}
+
+static void
+notify_output_post_frame(struct wl_listener *listener, void *data)
+{
+	struct timespec now;
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.post_frame);
+	struct tw_output_device *device = output->output->device;
+	struct tw_render_output *render_output =
+		wl_container_of(device, render_output, device);
+
+	clock_gettime(device->clk_id, &now);
+	update_output_frame_time(output, &output->state.ts, &now);
+	tw_render_output_flush_frame(render_output, &now);
+	//TODO: add profiler
+}
+
+static void
+notify_output_present(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.present);
+	struct tw_event_output_device_present *event = data;
+
+	output->state.last_present = event->time;
+}
+
+static void
+notify_output_clock_reset(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.clock_reset);
+	output->state.ft_idx = 0;
+	memset(output->state.fts, 0, sizeof(output->state.fts));
+}
+
+static void
+notify_output_destroy(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output *output =
+		wl_container_of(listener, output, listeners.destroy);
+
+        tw_server_output_fini(output);
+	//this basically on output lost
+}
+
+/******************************************************************************
+ * constructor/destructor
+ *****************************************************************************/
+
+static void
+tw_server_output_fini(struct tw_server_output *output)
+{
+	wl_event_source_remove(output->state.frame_timer);
+	output->state.frame_timer = NULL;
+	output->output = NULL;
+
+	tw_reset_wl_list(&output->listeners.destroy.link);
+	tw_reset_wl_list(&output->listeners.need_frame.link);
+	tw_reset_wl_list(&output->listeners.pre_frame.link);
+	tw_reset_wl_list(&output->listeners.post_frame.link);
+	tw_reset_wl_list(&output->listeners.present.link);
+}
+
+static void
+tw_server_output_init(struct tw_server_output *output,
+                      struct tw_engine_output *engine_output,
+                      struct tw_render_context *ctx)
+{
+	struct tw_output_device *device = engine_output->device;
+	struct tw_render_output *render_output =
+		wl_container_of(device, render_output, device);
+	struct wl_display *display = engine_output->engine->display;
+	struct wl_event_loop *loop = wl_display_get_event_loop(display);
+
+        output->output = engine_output;
+        output->state.frame_timer =
+	        wl_event_loop_add_timer(loop, notify_output_frame, output);
+
+        tw_signal_setup_listener(&render_output->signals.need_frame,
+                                 &output->listeners.need_frame,
+                                 notify_output_reshedule_frame);
+        tw_signal_setup_listener(&render_output->signals.pre_frame,
+                                 &output->listeners.pre_frame,
+                                 notify_output_pre_frame);
+        tw_signal_setup_listener(&render_output->signals.post_frame,
+                                 &output->listeners.post_frame,
+                                 notify_output_post_frame);
+        tw_signal_setup_listener(&device->signals.present,
+                                 &output->listeners.present,
+                                 notify_output_present);
+        //device signals
+        tw_signal_setup_listener(&device->signals.clock_reset,
+                                 &output->listeners.clock_reset,
+                                 notify_output_clock_reset);
+        tw_signal_setup_listener(&device->signals.destroy,
+                                 &output->listeners.destroy,
+                                 notify_output_destroy);
+}
+
+/******************************************************************************
+ * manager listeners
+ *****************************************************************************/
+
+static void
+notify_mgr_tw_surface_dirty(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output_manager *mgr =
+		wl_container_of(listener, mgr, listeners.surface_dirty);
+	struct tw_surface *surface = data;
+	struct tw_render_surface *render_surface =
+		wl_container_of(surface, render_surface, surface);
+	struct tw_render_context *ctx = mgr->ctx;
+	struct tw_render_output *output;
+
+	if (pixman_region32_not_empty(&surface->geometry.dirty))
+		reassign_surface_outputs(render_surface, ctx);
+
+	wl_list_for_each(output, &ctx->outputs, link) {
+		if ((1u << output->device.id) & render_surface->output_mask)
+			tw_render_output_dirty(output);
+	}
+}
+
+static void
+notify_mgr_tw_surface_lost(struct wl_listener *listener, void *data)
+{
+	//TODO just dirty the output regards the surface damage.
+}
+
+static void
+notify_mgr_new_output(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output_manager *mgr =
+		wl_container_of(listener, mgr, listeners.new_output);
+	struct tw_engine_output *output = data;
+	unsigned id = output->device->id;
+
+	tw_server_output_init(&mgr->outputs[id], output, mgr->ctx);
+}
+
+static void
+notify_mgr_render_context_lost(struct wl_listener *listener, void *data)
+{
+	struct tw_server_output_manager *mgr =
+		wl_container_of(listener, mgr, listeners.context_destroy);
+
+        mgr->ctx = NULL;
+	mgr->engine = NULL;
+
+	tw_reset_wl_list(&mgr->listeners.context_destroy.link);
+	tw_reset_wl_list(&mgr->listeners.surface_dirty.link);
+	tw_reset_wl_list(&mgr->listeners.surface_lost.link);
+	tw_reset_wl_list(&mgr->listeners.new_output.link);
+}
+
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx)
+{
+	static struct tw_server_output_manager mgr = {0};
+
+	mgr.engine = engine;
+	mgr.ctx = ctx;
+
+	tw_signal_setup_listener(&engine->signals.output_created,
+	                         &mgr.listeners.new_output,
+	                         notify_mgr_new_output);
+	tw_signal_setup_listener(&ctx->signals.wl_surface_dirty,
+	                         &mgr.listeners.surface_dirty,
+	                         notify_mgr_tw_surface_dirty);
+	tw_signal_setup_listener(&ctx->signals.wl_surface_destroy,
+	                         &mgr.listeners.surface_lost,
+	                         notify_mgr_tw_surface_lost);
+	tw_signal_setup_listener(&ctx->signals.destroy,
+	                         &mgr.listeners.context_destroy,
+	                         notify_mgr_render_context_lost);
+	return &mgr;
+}

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -241,9 +241,10 @@ notify_output_present(struct wl_listener *listener, void *data)
 {
 	struct tw_server_output *output =
 		wl_container_of(listener, output, listeners.present);
-	struct tw_event_output_device_present *event = data;
+	struct tw_event_output_present *event = data;
 
 	output->state.last_present = event->time;
+	SCOPE_PROFILE_TS();
 }
 
 static void
@@ -307,7 +308,7 @@ tw_server_output_init(struct tw_server_output *output,
         tw_signal_setup_listener(&render_output->signals.post_frame,
                                  &output->listeners.post_frame,
                                  notify_output_post_frame);
-        tw_signal_setup_listener(&device->signals.present,
+        tw_signal_setup_listener(&render_output->signals.present,
                                  &output->listeners.present,
                                  notify_output_present);
         //device signals

--- a/compositor/output.c
+++ b/compositor/output.c
@@ -29,6 +29,7 @@
 #include <taiwins/objects/utils.h>
 #include <taiwins/engine.h>
 #include <taiwins/backend.h>
+#include <taiwins/profiling.h>
 #include <taiwins/render_output.h>
 #include <taiwins/render_context.h>
 #include <taiwins/render_surface.h>
@@ -36,7 +37,6 @@
 #include <wayland-util.h>
 
 #include "output.h"
-#include "taiwins/objects/surface.h"
 
 static void
 tw_server_output_fini(struct tw_server_output *output);
@@ -217,7 +217,7 @@ notify_output_pre_frame(struct wl_listener *listener, void *data)
 	struct tw_output_device *device = output->output->device;
 
 	clock_gettime(device->clk_id, &output->state.ts);
-	//TODO add profiler
+	PROFILE_BEG("notify_output_repaint");
 }
 
 static void
@@ -233,7 +233,7 @@ notify_output_post_frame(struct wl_listener *listener, void *data)
 	clock_gettime(device->clk_id, &now);
 	update_output_frame_time(output, &output->state.ts, &now);
 	tw_render_output_flush_frame(render_output, &now);
-	//TODO: add profiler
+	PROFILE_END("notify_output_repaint");
 }
 
 static void

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -1,0 +1,88 @@
+/*
+ * output.h - taiwins server output headers
+ *
+ * Copyright (c) 2021 Xichen Zhou
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef TAIWINS_OUTPUT_H
+#define TAIWINS_OUTPUT_H
+
+#include <time.h>
+#include <wayland-server-core.h>
+#include <wayland-server.h>
+#include <taiwins/engine.h>
+#include <taiwins/render_context.h>
+#include <taiwins/objects/compositor.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#define TW_FRAME_TIME_CNT 8
+
+//we shall see how this works
+struct tw_server_output {
+	struct tw_engine_output *output;
+
+	struct {
+		/** average frame time in microseconds */
+		uint32_t fts[TW_FRAME_TIME_CNT], ft_idx;
+		struct timespec ts; /** used for recording start of frame */
+		struct timespec last_present;
+		struct wl_event_source *frame_timer;
+	} state;
+
+	struct {
+		/**< device signals */
+		struct wl_listener destroy;
+                struct wl_listener present;
+		struct wl_listener clock_reset;
+		/**< render_output signals */
+		struct wl_listener need_frame;
+		struct wl_listener pre_frame;
+		struct wl_listener post_frame;
+	} listeners;
+};
+
+struct tw_server_output_manager {
+
+	struct tw_engine *engine;
+	struct tw_render_context *ctx;
+
+	//reflect to the engine
+	struct tw_server_output outputs[32];
+
+	struct {
+		struct wl_listener context_destroy;
+		struct wl_listener surface_dirty;
+		struct wl_listener surface_lost;
+		struct wl_listener new_output;
+	} listeners;
+
+};
+
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
+
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* EOF */

--- a/include/taiwins/engine.h
+++ b/include/taiwins/engine.h
@@ -76,8 +76,6 @@ struct tw_engine_output {
 		struct wl_listener set_mode;
 		struct wl_listener destroy;
 		struct wl_listener present;
-		struct wl_listener surface_enter;
-		struct wl_listener surface_leave;
 	} listeners;
 };
 
@@ -171,6 +169,13 @@ tw_engine_output_from_resource(struct tw_engine *engine,
 struct tw_engine_output *
 tw_engine_output_from_device(struct tw_engine *engine,
                              const struct tw_output_device *device);
+void
+tw_engine_output_notify_surface_enter(struct tw_engine_output *output,
+                                      struct tw_surface *surface);
+void
+tw_engine_output_notify_surface_leave(struct tw_engine_output *output,
+                                      struct tw_surface *surface);
+
 
 #ifdef  __cplusplus
 }

--- a/include/taiwins/output_device.h
+++ b/include/taiwins/output_device.h
@@ -58,14 +58,6 @@ struct tw_output_device_impl {
 	bool (*commit_state) (struct tw_output_device *device);
 };
 
-struct tw_event_output_device_present {
-	struct tw_output_device *device;
-	struct timespec time;
-	uint32_t flags;
-	uint64_t seq;
-	int refresh;
-};
-
 /**
  * @brief abstraction of an output device
  *
@@ -96,8 +88,6 @@ struct tw_output_device {
 
 	struct {
 		struct wl_signal destroy;
-		/** new frame just presented on the output */
-		struct wl_signal present;
 		/** emit when general wl_output information is available, or
 		 * when output state changed */
                 struct wl_signal info;
@@ -164,9 +154,6 @@ tw_output_device_match_mode(struct tw_output_device *device,
 void
 tw_output_device_commit_state(struct tw_output_device *device);
 
-void
-tw_output_device_present(struct tw_output_device *device,
-                         struct tw_event_output_device_present *event);
 bool
 tw_output_device_mode_eq(const struct tw_output_device_mode *a,
                          const struct tw_output_device_mode *b);

--- a/include/taiwins/output_device.h
+++ b/include/taiwins/output_device.h
@@ -24,6 +24,7 @@
 
 #include <stdint.h>
 #include <time.h>
+#include <wayland-server-core.h>
 #include <wayland-server.h>
 #include <pixman.h>
 
@@ -92,12 +93,9 @@ struct tw_output_device {
 	struct wl_list mode_list;
 
 	struct tw_output_device_state current, pending;
-	struct timespec last_present;
 
 	struct {
 		struct wl_signal destroy;
-		/** new frame requested */
-		struct wl_signal new_frame;
 		/** new frame just presented on the output */
 		struct wl_signal present;
 		/** emit when general wl_output information is available, or
@@ -106,6 +104,8 @@ struct tw_output_device {
 		/** emit right after applying pending state, backend could
 		 * listen on this for applying the states to the hardware */
 		struct wl_signal commit_state;
+                /** emit on clock need to reset for output device. */
+		struct wl_signal clock_reset;
 	} signals;
 };
 
@@ -145,6 +145,14 @@ tw_output_device_set_current_mode(struct tw_output_device *device,
 		device->current.current_mode.refresh = refresh;
 		wl_signal_emit(&device->signals.commit_state, device);
 		wl_signal_emit(&device->signals.info, device);
+}
+
+//TODO: dont expose this, only backends are using it.
+static inline void
+tw_output_device_reset_clock(struct tw_output_device *device, clockid_t clk)
+{
+	device->clk_id = clk;
+	wl_signal_emit(&device->signals.clock_reset, device);
 }
 
 void

--- a/include/taiwins/profiling.h
+++ b/include/taiwins/profiling.h
@@ -34,12 +34,16 @@ extern "C" {
 
 #define SCOPE_PROFILE_BEG() tw_profiler_start_timer(__func__)
 #define SCOPE_PROFILE_END() tw_profiler_stop_timer(__func__)
+#define PROFILE_BEG(name) tw_profiler_start_timer(name)
+#define PROFILE_END(name) tw_profiler_stop_timer(name)
 #define SCOPE_PROFILE_TS() tw_profiler_timestamp(__func__)
 
 #else
 
 #define SCOPE_PROFILE_BEG()
 #define SCOPE_PROFILE_END()
+#define PROFILE_BEG(name)
+#define PROFILE_END(name)
 #define SCOPE_PROFILE_TS()
 #endif
 

--- a/include/taiwins/render_context.h
+++ b/include/taiwins/render_context.h
@@ -129,9 +129,6 @@ void
 tw_render_context_build_view_list(struct tw_render_context *ctx,
                                   struct tw_layers_manager *manager);
 void
-tw_render_surface_reassign_outputs(struct tw_render_surface *render_surface,
-                                   struct tw_render_context *ctx);
-void
 tw_render_context_set_dma(struct tw_render_context *ctx,
                           struct tw_linux_dmabuf *dma);
 void

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -73,8 +73,6 @@ struct tw_render_output {
 
 	/* TODO: maybe move this to engine_output? */
 	struct {
-		struct wl_signal surface_enter;
-		struct wl_signal surface_leave;
 		struct wl_signal need_frame;
 		struct wl_signal pre_frame;
 		struct wl_signal post_frame;

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -69,7 +69,6 @@ struct tw_render_output {
 	struct {
 		struct wl_listener set_mode; /* device::set_mode */
 		struct wl_listener destroy; /* device::destroy */
-		struct wl_listener surface_dirty; /* context::surface_dirty */
 	} listeners;
 
 	/* TODO: maybe move this to engine_output? */

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -46,6 +46,14 @@ enum tw_render_output_repaint_state {
 	TW_REPAINT_COMMITTED = 6, /**< repaint done, need swap */
 };
 
+struct tw_event_output_present {
+	struct tw_render_output *output;
+	struct timespec time;
+	uint32_t flags;
+	uint64_t seq;
+	int refresh;
+};
+
 struct tw_render_output {
 	struct tw_output_device device;
 	struct tw_render_presentable surface;
@@ -76,6 +84,7 @@ struct tw_render_output {
 		struct wl_signal need_frame;
 		struct wl_signal pre_frame;
 		struct wl_signal post_frame;
+		struct wl_signal present;
 	} signals;
 };
 
@@ -91,6 +100,11 @@ tw_render_output_set_context(struct tw_render_output *output,
                              struct tw_render_context *ctx);
 void
 tw_render_output_unset_context(struct tw_render_output *output);
+
+//TODO: dont expose this
+void
+tw_render_output_present(struct tw_render_output *output,
+                         struct tw_event_output_present *event);
 
 void
 tw_render_output_dirty(struct tw_render_output *output);

--- a/include/taiwins/render_output.h
+++ b/include/taiwins/render_output.h
@@ -64,13 +64,9 @@ struct tw_render_output {
 		struct tw_mat3 view_2d; /* global to output space */
 
 		uint32_t repaint_state;
-		/** average frame time in microseconds */
-		uint32_t fts[TW_FRAME_TIME_CNT], ft_idx;
-		/** additional checks for running render_output */
 	} state;
 
 	struct {
-		struct wl_listener frame; /* device::new_frame */
 		struct wl_listener set_mode; /* device::set_mode */
 		struct wl_listener destroy; /* device::destroy */
 		struct wl_listener surface_dirty; /* context::surface_dirty */
@@ -80,6 +76,9 @@ struct tw_render_output {
 	struct {
 		struct wl_signal surface_enter;
 		struct wl_signal surface_leave;
+		struct wl_signal need_frame;
+		struct wl_signal pre_frame;
+		struct wl_signal post_frame;
 	} signals;
 };
 
@@ -91,26 +90,34 @@ void
 tw_render_output_fini(struct tw_render_output *output);
 
 void
-tw_render_output_reset_clock(struct tw_render_output *output, clockid_t clk);
-
-void
 tw_render_output_set_context(struct tw_render_output *output,
                              struct tw_render_context *ctx);
 void
 tw_render_output_unset_context(struct tw_render_output *output);
 
 void
-tw_render_output_rebuild_view_mat(struct tw_render_output *output);
-
-void
 tw_render_output_dirty(struct tw_render_output *output);
 
+/**
+ * @brief flush frame will send wl_callback::done for the wl_surfaces.
+ *
+ * It is enssential to call this at some point after the frame rendering is
+ * done as wayland clients reply on this to draw next frame.
+ */
 void
-tw_render_output_schedule_frame(struct tw_render_output *output);
-
+tw_render_output_flush_frame(struct tw_render_output *output,
+                             const struct timespec *now);
+/**
+ * @brief posting a render request to render_output
+ *
+ * User may call this upon receiving a need_frame signal to trigger the actual
+ * rendering, the render_output would repaint if there is no repainting started
+ * already
+ */
 void
-tw_render_output_commit(struct tw_render_output *output);
+tw_render_output_post_frame(struct tw_render_output *output);
 
+//TODO: don't expose this, only used by backends
 void
 tw_render_output_clean_maybe(struct tw_render_output *output);
 

--- a/libtaiwins/backend/drm/drm.c
+++ b/libtaiwins/backend/drm/drm.c
@@ -191,11 +191,11 @@ handle_page_flip2(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec,
                   unsigned crtc_id, void *data)
 {
 	struct tw_drm_display *output = data;
-	struct tw_output_device *device = output ?
-		&output->output.device : NULL;
+	struct tw_render_output *render_output = output ?
+		&output->output : NULL;
 
-	struct tw_event_output_device_present present = {
-		.device = device,
+	struct tw_event_output_present present = {
+		.output = render_output,
 		.time = {
 			.tv_sec = tv_sec,
 			.tv_nsec = tv_usec * 1000,
@@ -207,7 +207,7 @@ handle_page_flip2(int fd, unsigned seq, unsigned tv_sec, unsigned tv_usec,
 	if (output) {
                 assert(output->gpu->gpu_fd == fd);
 		tw_drm_display_handle_page_flipped(output, crtc_id);
-                tw_output_device_present(device, &present);
+                tw_render_output_present(render_output, &present);
 	}
 }
 

--- a/libtaiwins/backend/headless.c
+++ b/libtaiwins/backend/headless.c
@@ -91,7 +91,7 @@ notify_output_commit(struct wl_listener *listener, void *data)
 {
 	struct tw_headless_output *output =
 		wl_container_of(listener, output, present_listener);
-	tw_output_device_present(&output->output.device, NULL);
+	tw_render_output_present(&output->output, NULL);
 	tw_render_output_clean_maybe(&output->output);
 }
 

--- a/libtaiwins/backend/headless.c
+++ b/libtaiwins/backend/headless.c
@@ -80,7 +80,7 @@ headless_frame(void *data)
 {
 	struct tw_headless_output *output = data;
 
-	wl_signal_emit(&output->output.device.signals.new_frame,
+	wl_signal_emit(&output->output.signals.need_frame,
 	               &output->output.device);
 	wl_event_source_timer_update(output->timer, 1000000 / (60 * 1000));
 	return 0;

--- a/libtaiwins/backend/wayland/backend.c
+++ b/libtaiwins/backend/wayland/backend.c
@@ -180,7 +180,7 @@ handle_presentation_clock_id(void *data,
 	wl->clk_id = clk_id;
 
 	wl_list_for_each(surface, &wl->base.outputs, output.device.link)
-		tw_render_output_reset_clock(&surface->output, clk_id);
+		tw_output_device_reset_clock(&surface->output.device, clk_id);
 }
 
 static const struct wp_presentation_listener presentation_listener = {

--- a/libtaiwins/backend/wayland/output.c
+++ b/libtaiwins/backend/wayland/output.c
@@ -427,7 +427,7 @@ tw_wl_backend_new_output(struct tw_backend *backend,
 	output->wl = wl;
 	tw_render_output_init(&output->output, &output_impl,
 	                      wl->server_display);
-	tw_render_output_reset_clock(&output->output, wl->clk_id);
+	tw_output_device_reset_clock(&output->output.device, wl->clk_id);
         tw_output_device_set_custom_mode(&output->output.device, width, height,
                                          0);
 

--- a/libtaiwins/backend/wayland/output.c
+++ b/libtaiwins/backend/wayland/output.c
@@ -195,15 +195,15 @@ handle_feedback_presented(void *data,
 		.tv_sec = ((uint64_t)tv_sec_hi << 32) | tv_sec_lo,
 		.tv_nsec = tv_nsec,
 	};
-	struct tw_event_output_device_present event = {
-		.device = &output->output.device,
+	struct tw_event_output_present event = {
+		.output = &output->output,
 		.time = time,
 		.seq = ((uint64_t)seq_hi << 32) | seq_lo,
 		.refresh = refresh,
 		.flags = flags,
 	};
 
-	tw_output_device_present(&output->output.device, &event);
+	tw_render_output_present(&output->output, &event);
 	wp_presentation_feedback_destroy(wp_feedback);
 }
 
@@ -212,7 +212,7 @@ handle_feedback_discarded(void *data,
                           struct wp_presentation_feedback *wp_feedback)
 {
 	struct tw_wl_surface *output = data;
-	tw_output_device_present(&output->output.device, NULL);
+	tw_render_output_present(&output->output, NULL);
 	wp_presentation_feedback_destroy(wp_feedback);
 }
 
@@ -332,7 +332,7 @@ notify_output_commit(struct wl_listener *listener, void *data)
 		                                      &feedback_listener,
 		                                      output);
 	else
-		tw_output_device_present(&output->output.device, NULL);
+		tw_render_output_present(&output->output, NULL);
 	tw_render_output_clean_maybe(&output->output);
 }
 

--- a/libtaiwins/backend/x11/backend.c
+++ b/libtaiwins/backend/x11/backend.c
@@ -58,25 +58,11 @@ handle_x11_configure_notify(struct tw_output_device *device,
 		                                  refresh);
 }
 
-static void
-handle_new_x11_frame(void *data)
-{
-	struct tw_x11_output *output = data;
-
-	wl_signal_emit(&output->output.device.signals.new_frame,
-	               &output->output.device);
-}
-
-static void
+static inline void
 handle_x11_request_frame(struct tw_x11_backend *x11,
                          struct tw_x11_output *output)
 {
-	struct wl_display *display = x11->display;
-	struct wl_event_loop *loop = wl_display_get_event_loop(display);
-
-	if (!loop)
-	        return;
-        wl_event_loop_add_idle(loop, handle_new_x11_frame, output);
+	tw_render_output_dirty(&output->output);
 }
 
 static int

--- a/libtaiwins/backend/x11/output.c
+++ b/libtaiwins/backend/x11/output.c
@@ -149,7 +149,7 @@ notify_output_commit(struct wl_listener *listener, void *data)
 		wl_container_of(listener, output, output_commit_listener);
 	//TODO: the x11 backend commit logic is broke here. in weston they wait
 	//for 10 ms then do the present
-	tw_output_device_present(&output->output.device, NULL);
+	tw_render_output_present(&output->output, NULL);
 	tw_render_output_clean_maybe(&output->output);
 }
 

--- a/libtaiwins/backend/x11/output.c
+++ b/libtaiwins/backend/x11/output.c
@@ -102,17 +102,11 @@ static const struct tw_output_device_impl x11_output_impl = {
 static int
 frame_handler(void *data)
 {
-	/* static long long oldtime = 0, newtime; */
-	/* struct timespec spec; */
 	struct tw_x11_output *output = data;
-	wl_signal_emit(&output->output.device.signals.new_frame,
-	               &output->output.device);
+	wl_signal_emit(&output->output.signals.need_frame,
+	               &output->output);
 	wl_event_source_timer_update(output->frame_timer,
 	                             FRAME_DELAY);
-	/* clock_gettime(CLOCK_MONOTONIC, &spec); */
-	/* newtime = (spec.tv_sec*1000000 + spec.tv_nsec/1000); */
-	/* tw_logl("time lapsed: %lld", newtime - oldtime); */
-	/* oldtime = newtime; */
 	return 0;
 }
 
@@ -153,6 +147,8 @@ notify_output_commit(struct wl_listener *listener, void *data)
 {
 	struct tw_x11_output *output =
 		wl_container_of(listener, output, output_commit_listener);
+	//TODO: the x11 backend commit logic is broke here. in weston they wait
+	//for 10 ms then do the present
 	tw_output_device_present(&output->output.device, NULL);
 	tw_render_output_clean_maybe(&output->output);
 }
@@ -165,7 +161,9 @@ tw_x11_output_resize(struct tw_x11_output *output)
 	                                &values[0], &values[1]);
 
 	xcb_configure_window(output->x11->xcb_conn,
-	                     output->win, XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
+	                     output->win,
+	                     XCB_CONFIG_WINDOW_WIDTH |
+	                     XCB_CONFIG_WINDOW_HEIGHT,
 	                     values);
 	xcb_flush(output->x11->xcb_conn);
 }

--- a/libtaiwins/engine/output.c
+++ b/libtaiwins/engine/output.c
@@ -146,7 +146,7 @@ notify_output_present(struct wl_listener *listener, void *data)
 	struct tw_engine_output *output =
 		wl_container_of(listener, output, listeners.present);
 	struct tw_engine *engine = output->engine;
-	struct tw_event_output_device_present *event = data;
+	struct tw_event_output_present *event = data;
 
 	wl_list_for_each_safe(feedback, tmp, &engine->presentation.feedbacks,
 	                      link) {
@@ -206,7 +206,7 @@ tw_engine_new_output(struct tw_engine *engine,
 	tw_signal_setup_listener(&device->signals.commit_state,
 	                         &output->listeners.set_mode,
 	                         notify_output_new_mode);
-	tw_signal_setup_listener(&device->signals.present,
+	tw_signal_setup_listener(&render_output->signals.present,
 	                         &output->listeners.present,
 	                         notify_output_present);
         engine->output_pool |= 1 << id;

--- a/libtaiwins/output_device.c
+++ b/libtaiwins/output_device.c
@@ -74,7 +74,6 @@ tw_output_device_init(struct tw_output_device *device,
 
 	wl_signal_init(&device->signals.destroy);
 	wl_signal_init(&device->signals.info);
-	wl_signal_init(&device->signals.present);
 	wl_signal_init(&device->signals.commit_state);
 	wl_signal_init(&device->signals.clock_reset);
 }
@@ -192,25 +191,6 @@ tw_output_device_commit_state(struct tw_output_device *device)
 		//emit for sending new backend info.
 		wl_signal_emit(&device->signals.info, device);
 	}
-}
-
-WL_EXPORT void
-tw_output_device_present(struct tw_output_device *device,
-                         struct tw_event_output_device_present *event)
-{
-	uint32_t mhz = device->current.current_mode.refresh;
-	struct tw_event_output_device_present _event = {
-		.device = device,
-	};
-	struct timespec now;
-	if (event == NULL) {
-		event = &_event;
-		clock_gettime(device->clk_id, &now);
-		event->time = now;
-	}
-	SCOPE_PROFILE_TS();
-	event->refresh = tw_millihertz_to_ns(mhz);
-	wl_signal_emit(&device->signals.present, event);
 }
 
 static void

--- a/libtaiwins/output_device.c
+++ b/libtaiwins/output_device.c
@@ -74,10 +74,9 @@ tw_output_device_init(struct tw_output_device *device,
 
 	wl_signal_init(&device->signals.destroy);
 	wl_signal_init(&device->signals.info);
-	wl_signal_init(&device->signals.new_frame);
-	wl_signal_init(&device->signals.info);
 	wl_signal_init(&device->signals.present);
 	wl_signal_init(&device->signals.commit_state);
+	wl_signal_init(&device->signals.clock_reset);
 }
 
 WL_EXPORT void
@@ -210,7 +209,6 @@ tw_output_device_present(struct tw_output_device *device,
 		event->time = now;
 	}
 	SCOPE_PROFILE_TS();
-	device->last_present = event->time;
 	event->refresh = tw_millihertz_to_ns(mhz);
 	wl_signal_emit(&device->signals.present, event);
 }

--- a/libtaiwins/render/render_context.c
+++ b/libtaiwins/render/render_context.c
@@ -62,7 +62,7 @@ notify_tw_surface_output_lost(struct wl_listener *listener, void *data)
 {
 	struct tw_render_surface *surface =
 		wl_container_of(listener, surface, listeners.output_lost);
-	tw_render_surface_reassign_outputs(surface, surface->ctx);
+	tw_surface_dirty_geometry(&surface->surface);
 }
 
 static void
@@ -285,73 +285,6 @@ tw_render_context_build_view_list(struct tw_render_context *ctx,
 	SCOPE_PROFILE_END();
 }
 
-static void
-update_surface_mask(struct tw_surface *base, struct tw_render_context *ctx,
-                    struct tw_render_output *major, uint32_t mask)
-{
-	struct tw_render_output *output;
-	struct tw_render_surface *surface =
-		wl_container_of(base, surface, surface);
-	uint32_t output_bit;
-	uint32_t different = surface->output_mask ^ mask;
-	uint32_t entered = mask & different;
-	uint32_t left = surface->output_mask & different;
-
-	//update the surface_mask and
-	surface->output_mask = mask;
-	surface->output = major ? major->device.id : -1;
-
-	wl_list_for_each(output, &ctx->outputs, link) {
-		output_bit = 1u << output->device.id;
-		if (!(output_bit & different))
-			continue;
-		if ((output_bit & entered))
-			wl_signal_emit(&output->signals.surface_enter, base);
-		if ((output_bit & left))
-			wl_signal_emit(&output->signals.surface_leave, base);
-	}
-}
-
-WL_EXPORT void
-tw_render_surface_reassign_outputs(struct tw_render_surface *render_surface,
-                                   struct tw_render_context *ctx)
-{
-	uint32_t area = 0, max = 0, mask = 0;
-	struct tw_render_output *output, *major = NULL;
-	pixman_region32_t surface_region;
-	pixman_box32_t *e;
-	struct tw_surface *surface = &render_surface->surface;
-
-	pixman_region32_init_rect(&surface_region,
-	                          surface->geometry.xywh.x,
-	                          surface->geometry.xywh.y,
-	                          surface->geometry.xywh.width,
-	                          surface->geometry.xywh.height);
-	wl_list_for_each(output, &ctx->outputs, link) {
-		pixman_region32_t clip;
-		struct tw_output_device *device = &output->device;
-		pixman_rectangle32_t rect =
-			tw_output_device_geometry(device);
-		//TODO dealing with cloning output
-		// if (output->cloning >= 0)
-		//	continue;
-		pixman_region32_init_rect(&clip, rect.x, rect.y,
-		                          rect.width, rect.height);
-		pixman_region32_intersect(&clip, &clip, &surface_region);
-		e = pixman_region32_extents(&clip);
-		area = (e->x2 - e->x1) * (e->y2 - e->y1);
-		if (pixman_region32_not_empty(&clip))
-			mask |= (1u << device->id);
-		if (area >= max) {
-			major = output;
-			max = area;
-		}
-		pixman_region32_fini(&clip);
-	}
-	pixman_region32_fini(&surface_region);
-
-	update_surface_mask(surface, ctx, major, mask);
-}
 
 WL_EXPORT void
 tw_render_context_set_compositor(struct tw_render_context *ctx,

--- a/libtaiwins/render/render_output.c
+++ b/libtaiwins/render/render_output.c
@@ -199,8 +199,6 @@ tw_render_output_init(struct tw_render_output *output,
 	wl_signal_init(&output->signals.need_frame);
 	wl_signal_init(&output->signals.pre_frame);
 	wl_signal_init(&output->signals.post_frame);
-	wl_signal_init(&output->signals.surface_enter);
-	wl_signal_init(&output->signals.surface_leave);
 
 	tw_signal_setup_listener(&output->device.signals.destroy,
 	                         &output->listeners.destroy,

--- a/libtaiwins/render/render_output.c
+++ b/libtaiwins/render/render_output.c
@@ -19,7 +19,6 @@
  *
  */
 
-#include "options.h"
 #include <assert.h>
 #include <time.h>
 #include <pixman.h>
@@ -34,7 +33,6 @@
 #include <taiwins/render_output.h>
 #include <taiwins/render_surface.h>
 #include <taiwins/render_pipeline.h>
-#include <taiwins/profiling.h>
 #include <ctypes/helpers.h>
 
 static inline bool
@@ -77,6 +75,35 @@ fini_output_state(struct tw_render_output *o)
 		pixman_region32_fini(&o->state.damages[i]);
 }
 
+static void
+rebuild_render_output_view_mat(struct tw_render_output *output)
+{
+	struct tw_mat3 glproj, tmp;
+	int width, height;
+	const struct tw_output_device_state *state = &output->device.current;
+	pixman_rectangle32_t rect = tw_output_device_geometry(&output->device);
+
+	//the transform should be
+	// T' = glproj * inv_wl_transform * scale * -translate * T
+	width = rect.width;
+	height = rect.height;
+
+	//output scale and inverse transform.
+	tw_mat3_translate(&output->state.view_2d, -state->gx, -state->gy);
+	tw_mat3_transform_rect(&tmp, false,
+	                       inverse_wl_transform(state->transform),
+	                       width, height, state->scale);
+	//glproj matrix,
+	tw_mat3_init(&glproj);
+	glproj.d[4] = -1;
+	glproj.d[7] = state->current_mode.h;
+
+	tw_mat3_multiply(&output->state.view_2d, &tmp,
+	                 &output->state.view_2d);
+	tw_mat3_multiply(&output->state.view_2d, &glproj,
+	                 &output->state.view_2d);
+}
+
 /**
  * @brief manage the backend output damage state
  */
@@ -97,52 +124,36 @@ shuffle_output_damage(struct tw_render_output *output)
 	output->state.pending_damage = previous;
 }
 
-static void
-output_idle_frame(void *data)
-{
-	struct tw_render_output *output = data;
-	//TODO we should reset clock here
-	wl_signal_emit(&output->device.signals.new_frame, &output->device);
-}
-
 /*
- * update the frame time for the output.
- */
-static void
-update_output_frame_time(struct tw_render_output *output,
-                         const struct timespec *strt,
-                         const struct timespec *end)
+ * after commit, the output should not dirty anymore, but the schedule state
+ * should not change, it shield us from committing another frame before the
+ * pageflip/swapbuffer happens.
+*/
+static inline void
+commit_render_output(struct tw_render_output *output)
 {
-	uint32_t ft;
-	uint64_t tstart = tw_timespec_to_us(strt);
-	uint64_t tend = tw_timespec_to_us(end);
-
-	/* assert(tend >= tstart); */
-	ft = MAX((uint32_t)0, (uint32_t)(tend - tstart));
-	output->state.fts[output->state.ft_idx] = ft;
-	output->state.ft_idx = (output->state.ft_idx + 1) % TW_FRAME_TIME_CNT;
+	output->state.repaint_state = TW_REPAINT_COMMITTED;
+	tw_render_presentable_commit(&output->surface, output->ctx);
 }
 
-/* getting the max frame time in milliseconds */
-static uint32_t
-calc_output_max_frametime(struct tw_render_output *output)
+static int
+tick_render_output_frame(struct tw_render_output *output)
 {
-	uint32_t *fts = output->state.fts;
-	uint32_t ft = MAX(MAX(MAX(fts[0], fts[1]), MAX(fts[2],fts[3])),
-	                  MAX(MAX(fts[4], fts[5]), MAX(fts[6],fts[7])));
-	//ceil algorithm, output basically
-	return ft ? ((ft + 1000) / 1000) : ft;
-}
+	struct tw_render_presentable *presentable = &output->surface;
+	struct tw_render_context *ctx = output->ctx;
+	struct tw_render_pipeline *pipeline;
+	int buffer_age;
 
-static void
-flush_output_frame(struct tw_render_output *output,
-                   const struct timespec *now)
-{
-	struct tw_surface *surface;
-	uint32_t now_int = tw_timespec_to_ms(now);
+	assert(ctx);
+	buffer_age = tw_render_presentable_make_current(presentable, ctx);
+	buffer_age = (buffer_age < 0) ? 2 : buffer_age;
 
-	wl_list_for_each(surface, &output->views, links[TW_VIEW_OUTPUT_LINK])
-		tw_surface_flush_frame(surface, now_int);
+	wl_list_for_each(pipeline, &ctx->pipelines, link)
+		tw_render_pipeline_repaint(pipeline, output, buffer_age);
+
+	shuffle_output_damage(output);
+	commit_render_output(output);
+	return 0;
 }
 
 /******************************************************************************
@@ -169,94 +180,6 @@ notify_render_output_surface_dirty(struct wl_listener *listener, void *data)
 	}
 }
 
-static int
-notify_render_output_frame(void *data)
-{
-	struct tw_render_output *output = data;
-	struct tw_render_presentable *presentable = &output->surface;
-	struct tw_render_context *ctx = output->ctx;
-	struct tw_render_pipeline *pipeline;
-	struct timespec tstart, tend;
-	int buffer_age;
-	uint32_t should_repaint = TW_REPAINT_DIRTY | TW_REPAINT_SCHEDULED;
-
-	assert(ctx);
-	if (!output->device.current.enabled)
-		return 0;
-	if (!check_bits(output->state.repaint_state, should_repaint))
-		return 0;
-	if (check_bits(output->state.repaint_state, TW_REPAINT_COMMITTED))
-		return 0;
-
-	SCOPE_PROFILE_BEG();
-	clock_gettime(output->device.clk_id, &tstart);
-
-	buffer_age = tw_render_presentable_make_current(presentable, ctx);
-	buffer_age = (buffer_age < 0) ? 2 : buffer_age;
-
-	wl_list_for_each(pipeline, &ctx->pipelines, link)
-		tw_render_pipeline_repaint(pipeline, output, buffer_age);
-
-	shuffle_output_damage(output);
-
-	tw_render_output_commit(output);
-	clock_gettime(output->device.clk_id, &tend);
-	update_output_frame_time(output, &tstart, &tend);
-	flush_output_frame(output, &tend);
-	SCOPE_PROFILE_END();
-	return 0;
-}
-
-static void
-notify_render_output_frame_scheduled(struct wl_listener *listener, void *data)
-{
-	int delay, ms_left = 0; //< left for render
-	struct tw_render_output *output =
-		wl_container_of(listener, output, listeners.frame);
-	//TODO: change it to max frame time
-	int frametime = calc_output_max_frametime(output);
-
-	assert(&output->device == data);
-	if (!output->device.current.enabled)
-		return;
-
-	if (frametime) { //becomes max_render_time
-		struct timespec now;
-		//get current time as soon as possible
-		clock_gettime(output->device.clk_id, &now);
-
-		struct timespec predict_refresh = output->device.last_present;
-		unsigned mhz = output->device.current.current_mode.refresh;
-		uint32_t refresh = tw_millihertz_to_ns(mhz);
-
-		//getting a predicted vblank. 1): If we are scheduled right
-		//after a vsync, there are chance predict_refresh is ahead of
-		//us. 2) If we come from a idle frame, predict_time will be
-		//less than now, in that case, we just draw
-
-		predict_refresh.tv_nsec += refresh % TW_NS_PER_S;
-		predict_refresh.tv_sec += refresh / TW_NS_PER_S;
-		if (predict_refresh.tv_nsec >= TW_NS_PER_S) {
-			predict_refresh.tv_sec += 1;
-			predict_refresh.tv_nsec -= TW_NS_PER_S;
-		}
-
-		//this is the floored difference.
-		if (predict_refresh.tv_sec >= now.tv_sec)
-			ms_left = tw_timespec_diff_ms(&predict_refresh, &now);
-	}
-	//here we added 2 extra ms frametime, it seems with amount, we are
-	//able to catch up with next vblank. TODO we can we not rely on this,
-	//otherwise we would have to move this repaint logic out of libtaiwins.
-	delay = (ms_left - (frametime + 2));
-
-	if (delay < 1) {
-		notify_render_output_frame(output);
-	} else {
-		wl_event_source_timer_update(output->repaint_timer, delay);
-	}
-}
-
 static void
 notify_render_output_destroy(struct wl_listener *listener, void *data)
 {
@@ -270,7 +193,7 @@ notify_render_output_new_mode(struct wl_listener *listener, void *data)
 {
 	struct tw_render_output *output =
 		wl_container_of(listener, output, listeners.set_mode);
-	tw_render_output_rebuild_view_mat(output);
+	rebuild_render_output_view_mat(output);
 }
 
 /******************************************************************************
@@ -286,24 +209,21 @@ tw_render_output_init(struct tw_render_output *output,
 	output->surface.impl = NULL;
 	output->surface.handle = 0;
 	init_output_state(output);
-	//this cannot fail
-	output->repaint_timer = wl_event_loop_add_timer(
-		wl_display_get_event_loop(display),
-		notify_render_output_frame, output);
 
 	tw_output_device_init(&output->device, impl);
-	tw_render_output_reset_clock(output, CLOCK_MONOTONIC);
+	tw_output_device_reset_clock(&output->device, CLOCK_MONOTONIC);
 
 	wl_list_init(&output->link);
 
 	wl_signal_init(&output->surface.commit);
+	wl_signal_init(&output->signals.need_frame);
+	wl_signal_init(&output->signals.pre_frame);
+	wl_signal_init(&output->signals.post_frame);
 	wl_signal_init(&output->signals.surface_enter);
 	wl_signal_init(&output->signals.surface_leave);
 
 	wl_list_init(&output->listeners.surface_dirty.link);
-	tw_signal_setup_listener(&output->device.signals.new_frame,
-	                         &output->listeners.frame,
-	                         notify_render_output_frame_scheduled);
+
 	tw_signal_setup_listener(&output->device.signals.destroy,
 	                         &output->listeners.destroy,
 	                         notify_render_output_destroy);
@@ -317,7 +237,6 @@ tw_render_output_fini(struct tw_render_output *output)
 {
 	fini_output_state(output);
 	wl_list_remove(&output->listeners.destroy.link);
-	wl_list_remove(&output->listeners.frame.link);
 	wl_list_remove(&output->listeners.set_mode.link);
 	wl_list_remove(&output->listeners.surface_dirty.link);
 
@@ -328,35 +247,6 @@ tw_render_output_fini(struct tw_render_output *output)
 		output->repaint_timer = NULL;
 	}
 	tw_output_device_fini(&output->device);
-}
-
-WL_EXPORT void
-tw_render_output_rebuild_view_mat(struct tw_render_output *output)
-{
-	struct tw_mat3 glproj, tmp;
-	int width, height;
-	const struct tw_output_device_state *state = &output->device.current;
-	pixman_rectangle32_t rect = tw_output_device_geometry(&output->device);
-
-	//the transform should be
-	// T' = glproj * inv_wl_transform * scale * -translate * T
-	width = rect.width;
-	height = rect.height;
-
-	//output scale and inverse transform.
-	tw_mat3_translate(&output->state.view_2d, -state->gx, -state->gy);
-	tw_mat3_transform_rect(&tmp, false,
-	                       inverse_wl_transform(state->transform),
-	                       width, height, state->scale);
-	//glproj matrix,
-	tw_mat3_init(&glproj);
-	glproj.d[4] = -1;
-	glproj.d[7] = state->current_mode.h;
-
-	tw_mat3_multiply(&output->state.view_2d, &tmp,
-	                 &output->state.view_2d);
-	tw_mat3_multiply(&output->state.view_2d, &glproj,
-	                 &output->state.view_2d);
 }
 
 WL_EXPORT void
@@ -389,44 +279,41 @@ tw_render_output_unset_context(struct tw_render_output *output)
 }
 
 WL_EXPORT void
-tw_render_output_reset_clock(struct tw_render_output *output, clockid_t clk)
+tw_render_output_flush_frame(struct tw_render_output *output,
+                             const struct timespec *now)
 {
-	output->device.clk_id = clk;
-	output->state.ft_idx = 0;
-	memset(output->state.fts, 0, sizeof(output->state.fts));
+	struct tw_surface *surface;
+	uint32_t now_int = tw_timespec_to_ms(now);
+
+	wl_list_for_each(surface, &output->views, links[TW_VIEW_OUTPUT_LINK])
+		tw_surface_flush_frame(surface, now_int);
 }
 
 WL_EXPORT void
 tw_render_output_dirty(struct tw_render_output *output)
 {
 	output->state.repaint_state |= TW_REPAINT_DIRTY;
-	tw_render_output_schedule_frame(output);
-}
-
-/* schedule a frame, maybe for the purpose sending back empty frame_request */
-WL_EXPORT void
-tw_render_output_schedule_frame(struct tw_render_output *output)
-{
-	struct wl_display *display = output->ctx->display;
-	struct wl_event_loop *loop = wl_display_get_event_loop(display);
-
 	if (!(output->state.repaint_state & TW_REPAINT_SCHEDULED) &&
-	    output->device.current.enabled) {
-		wl_event_loop_add_idle(loop, output_idle_frame, output);
-		output->state.repaint_state |= TW_REPAINT_SCHEDULED;
-	}
+	    output->device.current.enabled)
+		wl_signal_emit(&output->signals.need_frame, output);
 }
 
-/*
- * after commit, the output should not dirty anymore, but the schedule state
- * should not change, it shield us from committing another frame before the
- * pageflip/swapbuffer happens.
-*/
 WL_EXPORT void
-tw_render_output_commit(struct tw_render_output *output)
+tw_render_output_post_frame(struct tw_render_output *output)
 {
-	output->state.repaint_state = TW_REPAINT_COMMITTED;
-	tw_render_presentable_commit(&output->surface, output->ctx);
+	if (!output->device.current.enabled)
+		return;
+	if (!(output->state.repaint_state & TW_REPAINT_DIRTY))
+		return;
+	if ((output->state.repaint_state & TW_REPAINT_SCHEDULED))
+		return;
+	if (check_bits(output->state.repaint_state, TW_REPAINT_COMMITTED))
+		return;
+
+	output->state.repaint_state |= TW_REPAINT_SCHEDULED;
+	wl_signal_emit(&output->signals.pre_frame, output);
+	tick_render_output_frame(output);
+	wl_signal_emit(&output->signals.post_frame, output);
 }
 
 /*

--- a/test/drm-test.c
+++ b/test/drm-test.c
@@ -20,6 +20,9 @@
 struct tw_render_pipeline *
 tw_egl_render_pipeline_create_default(struct tw_render_context *ctx,
                                       struct tw_layers_manager *manager);
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
 static inline void
 wait_for_debug()
 {
@@ -140,6 +143,8 @@ int main(int argc, char *argv[])
 	wl_list_insert(ctx->pipelines.next, &pipeline->link);
 
 	wait_for_debug();
+
+        tw_server_output_manager_create_global(engine, ctx);
 
 	tw_backend_start(backend, ctx);
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -71,7 +71,7 @@ test('test_headless', headless_test)
 if get_option('x11-backend').enabled()
   x11_test = executable(
     'tw-test-x11',
-    ['x11-test.c', '../compositor/egl_renderer.c', 'test_desktop.c',
+    ['x11-test.c', '../compositor/egl_renderer.c', '../compositor/output.c', 'test_desktop.c',
      wayland_taiwins_shell_server_protocol_h],
     c_args : debug_cargs,
     dependencies : dep_taiwins_lib,
@@ -82,7 +82,7 @@ endif
 
 wayland_test = executable(
   'tw-test-wayland',
-  ['wayland-test.c', '../compositor/egl_renderer.c', 'test_desktop.c',
+  ['wayland-test.c', '../compositor/egl_renderer.c', '../compositor/output.c', 'test_desktop.c',
    wayland_taiwins_shell_server_protocol_h],
   c_args : debug_cargs,
   dependencies : dep_taiwins_lib,
@@ -91,7 +91,7 @@ test('test_wayland', wayland_test)
 
 drm_test = executable(
   'tw-test-drm',
-  ['drm-test.c', '../compositor/egl_renderer.c', 'test_desktop.c' ],
+  ['drm-test.c', '../compositor/egl_renderer.c', '../compositor/output.c', 'test_desktop.c' ],
   c_args : debug_cargs,
   dependencies : dep_taiwins_lib,
 )

--- a/test/wayland-test.c
+++ b/test/wayland-test.c
@@ -19,6 +19,9 @@
 struct tw_render_pipeline *
 tw_egl_render_pipeline_create_default(struct tw_render_context *ctx,
                                       struct tw_layers_manager *manager);
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
 static void
 set_dirty(void *data)
 {
@@ -98,7 +101,7 @@ int main(int argc, char *argv[])
 		tw_egl_render_pipeline_create_default(ctx,
 		                                      &engine->layers_manager);
 	wl_list_insert(ctx->pipelines.next, &pipeline->link);
-
+        tw_server_output_manager_create_global(engine, ctx);
 	tw_backend_start(backend, ctx);
 
 	wl_display_run(display);

--- a/test/x11-test.c
+++ b/test/x11-test.c
@@ -36,6 +36,10 @@ struct data {
 struct tw_render_pipeline *
 tw_egl_render_pipeline_create_default(struct tw_render_context *ctx,
                                       struct tw_layers_manager *manager);
+struct tw_server_output_manager *
+tw_server_output_manager_create_global(struct tw_engine *engine,
+                                       struct tw_render_context *ctx);
+
 #ifdef _TW_HAS_XWAYLAND
 static void
 notify_xserver_ready(struct wl_listener *listener, void *data)
@@ -154,6 +158,8 @@ int main(int argc, char *argv[])
                                  &data.listeners.seat_focused,
                                  notify_xserver_seat_focused);
 #endif
+
+        tw_server_output_manager_create_global(engine, ctx);
 
 	tw_backend_start(backend, ctx);
 


### PR DESCRIPTION
`render_output` interface becomes too big.  Move those outside of libtaiwins.