### PR TITLE
tw_surface: introducing tw_surface_role.

### DIFF
--- a/include/taiwins/objects/surface.h
+++ b/include/taiwins/objects/surface.h
@@ -63,6 +63,18 @@ struct tw_event_buffer_uploading {
 };
 
 typedef void (*tw_surface_commit_cb_t)(struct tw_surface *surface);
+
+/**
+ * @brief role represents a type of surfaces to differentiate them from others
+ *
+ * It also contains a link for group differnt roles together
+ */
+struct tw_surface_role {
+	const char *name;
+	tw_surface_commit_cb_t commit;
+	struct wl_list link; /**< can be used for exotic role */
+};
+
 /**
  * @brief tw_surface_buffer represents a buffer texture for the surface.
  *
@@ -170,9 +182,8 @@ struct tw_surface {
 	} geometry;
 
 	struct {
-		const char *name;
+		const struct tw_surface_role *iface;
 		void *commit_private;
-		tw_surface_commit_cb_t commit;
 	} role;
 
 	struct {
@@ -222,8 +233,8 @@ bool
 tw_surface_has_role(struct tw_surface *surface);
 
 bool
-tw_surface_assign_role(struct tw_surface *surface, tw_surface_commit_cb_t cmt,
-                       void *user_data, const char *name);
+tw_surface_assign_role(struct tw_surface *surface,
+                       const struct tw_surface_role *role, void *user_data);
 
 /**
  * @brief dirty the geometry of the surface and subsurfaces.

--- a/libtaiwins/objects/surface.c
+++ b/libtaiwins/objects/surface.c
@@ -501,8 +501,8 @@ surface_commit_state(struct tw_surface *surface)
 	else if ((surface->current->commit_state & TW_SURFACE_FRAME_REQUESTED))
 		wl_signal_emit(&surface->signals.frame, surface);
 	//also commit the subsurface surface and
-	if (surface->role.commit)
-		surface->role.commit(surface);
+	if (surface->role.iface && surface->role.iface->commit)
+		surface->role.iface->commit(surface);
 }
 
 void
@@ -599,19 +599,17 @@ tw_surface_has_texture(struct tw_surface *surface)
 WL_EXPORT bool
 tw_surface_has_role(struct tw_surface *surface)
 {
-	return surface->role.commit != NULL;
+	return surface->role.iface != NULL;
 }
 
 WL_EXPORT bool
-tw_surface_assign_role(struct tw_surface *surface, tw_surface_commit_cb_t cmt,
-                       void *user_data, const char *name)
+tw_surface_assign_role(struct tw_surface *surface,
+                       const struct tw_surface_role *role, void *user_data)
 {
-	if (surface->role.commit != NULL &&
-	    surface->role.commit != cmt)
+	if (surface->role.iface != NULL && surface->role.iface != role)
 		return false;
-	surface->role.commit = cmt;
+	surface->role.iface = role;
 	surface->role.commit_private = user_data;
-	surface->role.name = name;
 	return true;
 }
 

--- a/libtaiwins/shell/shell_internal.h
+++ b/libtaiwins/shell/shell_internal.h
@@ -132,10 +132,9 @@ shell_create_ui_element(struct tw_shell *shell,
                         struct tw_shell_output *output,
                         uint32_t x, uint32_t y,
                         struct tw_layer *layer,
-                        tw_surface_commit_cb_t commit_cb);
+                        const struct tw_surface_role *role);
 void
-shell_ui_set_role(struct tw_shell_ui *ui,
-                  void (*commit)(struct tw_surface *surface),
+shell_ui_set_role(struct tw_shell_ui *ui, const struct tw_surface_role *role,
                   struct tw_surface *surface);
 
 struct tw_shell_output *

--- a/libtaiwins/shell/shell_layer.c
+++ b/libtaiwins/shell/shell_layer.c
@@ -270,6 +270,10 @@ layer_shell_handle_get_layer_surface(struct wl_client *wl_client,
                                      struct wl_resource *output_resource,
                                      uint32_t layer, const char *namespace)
 {
+	static const struct tw_surface_role layer_surface_role = {
+		.name = "layer-shell-surface",
+		.commit = commit_layer_surface,
+	};
 	struct tw_shell *shell =
 		tw_shell_from_layer_shell_resoruce(client_resource);
 	struct tw_engine_output *output;
@@ -307,7 +311,7 @@ layer_shell_handle_get_layer_surface(struct wl_client *wl_client,
 
 	shell_create_ui_element(shell, shell_ui, layer_surface_resource,
 	                        surface, shell_output, 0, 0,
-	                        l, commit_layer_surface);
+	                        l, &layer_surface_role);
 }
 
 static const struct zwlr_layer_shell_v1_interface layer_shell_impl = {

--- a/libtaiwins/xwayland/window.c
+++ b/libtaiwins/xwayland/window.c
@@ -729,6 +729,13 @@ handle_commit_tw_xsurface(struct tw_surface *tw_surface)
 
 }
 
+static struct tw_surface_role tw_xsurface_role = {
+	.commit = handle_commit_tw_xsurface,
+	.name = "xwayland-surface",
+	.link.prev = &tw_xsurface_role.link,
+	.link.next = &tw_xsurface_role.link,
+};
+
 static void
 handle_configure_tw_xsurface(struct tw_desktop_surface *dsurf,
                              enum wl_shell_surface_resize edge,
@@ -864,8 +871,7 @@ tw_xsurface_map_tw_surface(struct tw_xsurface *surface,
 		xwm->atoms.net_wm_pid,
 	};
 
-	if (!tw_surface_assign_role(tw_surface, handle_commit_tw_xsurface,
-	                            dsurf, "xwayland surface")) {
+	if (!tw_surface_assign_role(tw_surface, &tw_xsurface_role, dsurf)) {
 		wl_resource_post_error(tw_surface->resource, 0,
 		                       "wl_surface@d already has role");
 		return;
@@ -1023,7 +1029,7 @@ tw_xsurface_handle_event(struct tw_xwm *xwm, xcb_generic_event_t *ge)
 WL_EXPORT struct tw_desktop_surface *
 tw_xwayland_desktop_surface_from_tw_surface(struct tw_surface *surface)
 {
-	if (surface->role.commit == handle_commit_tw_xsurface)
+	if (surface->role.iface == &tw_xsurface_role)
 		return surface->role.commit_private;
 	return NULL;
 }


### PR DESCRIPTION
We no longer embed role directly inside tw_surface. This allows us to match
against role instead commit. And it is also possible to group different roles
together for need like subsurface or desktop_surface.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>