### PR TITLE
tw_input_signal_emit

### DIFF
--- a/include/taiwins/engine.h
+++ b/include/taiwins/engine.h
@@ -153,6 +153,7 @@ struct tw_engine {
 		struct wl_signal seat_created;
 		struct wl_signal seat_focused;
 		struct wl_signal seat_remove;
+		struct wl_signal seat_input;
 	} signals;
 };
 

--- a/include/taiwins/input_device.h
+++ b/include/taiwins/input_device.h
@@ -47,6 +47,7 @@ struct tw_input_device;
  */
 struct tw_input_source {
 	struct wl_signal remove; /* device remove */
+	struct wl_signal event; /* an input event emitted */
 
 	struct {
 		struct wl_signal key;
@@ -82,7 +83,8 @@ struct tw_input_source {
  * @brief this struct mirrors the tw_input_source for the listener side.
  */
 struct tw_input_sink {
-	struct wl_listener remove; /** device remove */
+	struct wl_listener remove; /* device remove */
+	struct wl_listener event; /* an input event emitted */
 
 	struct {
 		struct wl_listener key;
@@ -252,6 +254,19 @@ struct tw_event_touch_cancel {
 	uint32_t time_msec;
 	int32_t touch_id;
 };
+
+/**
+ * Emit input signals
+ *
+ * This macro emit an input signal, it notifies the specific event and also
+ * signal an input event is delivered. This makes it is easier to implement
+ * mechanisms like input inhibit
+ */
+#define tw_input_signal_emit(src, sig, ev) \
+	do { \
+		wl_signal_emit(&src->sig, ev); \
+		wl_signal_emit(&src->event, src); \
+	} while (0)
 
 /**
  * @brief attach the given input device to an emitter.

--- a/libtaiwins/backend/wayland/seat.c
+++ b/libtaiwins/backend/wayland/seat.c
@@ -174,8 +174,8 @@ handle_pointer_motion(void *data, struct wl_pointer *wl_pointer, uint32_t time,
 	event.y = wl_fixed_to_double(surface_y) / h;
 
 	if (pointer->emitter)
-		wl_signal_emit(&pointer->emitter->pointer.motion_absolute,
-		               &event);
+		tw_input_signal_emit(pointer->emitter, pointer.motion_absolute,
+		                     &event);
 }
 
 static void
@@ -193,8 +193,7 @@ handle_pointer_button(void *data, struct wl_pointer *wl_pointer,
 	};
 
 	if (pointer->emitter)
-		wl_signal_emit(&pointer->emitter->pointer.button,
-		               &event);
+		tw_input_signal_emit(pointer->emitter, pointer.button, &event);
 }
 
 static void
@@ -213,7 +212,7 @@ handle_pointer_axis(void *data, struct wl_pointer *wl_pointer,
 	};
 
 	if (pointer->emitter)
-		wl_signal_emit(&pointer->emitter->pointer.axis, &event);
+		tw_input_signal_emit(pointer->emitter, pointer.axis, &event);
 }
 
 static void
@@ -223,8 +222,7 @@ handle_pointer_frame(void *data, struct wl_pointer *wl_pointer)
 	struct tw_input_device *pointer = &seat->pointer_dev;
 
         if (pointer->emitter)
-		wl_signal_emit(&pointer->emitter->pointer.frame, pointer);
-
+	        tw_input_signal_emit(pointer->emitter, pointer.frame, pointer);
 }
 
 static void

--- a/libtaiwins/backend/x11/input.c
+++ b/libtaiwins/backend/x11/input.c
@@ -94,10 +94,10 @@ handle_x11_btn_axis(struct tw_x11_backend *x11,
 	axis.delta = 15.0 * axis.delta_discrete;
 
 	if (emitter && btn.button != 0) {
-		wl_signal_emit(&emitter->pointer.button, &btn);
+		tw_input_signal_emit(emitter, pointer.button, &btn);
 		wl_signal_emit(&emitter->pointer.frame, &output->pointer);
 	} else if (emitter && axis.delta_discrete != 0) {
-		wl_signal_emit(&emitter->pointer.axis, &axis);
+		tw_input_signal_emit(emitter, pointer.axis, &axis);
 		wl_signal_emit(&emitter->pointer.frame, &output->pointer);
 	}
 }
@@ -107,7 +107,7 @@ handle_x11_motion(struct tw_x11_backend *x11, xcb_ge_generic_event_t *ge)
 {
 	xcb_input_motion_event_t *ev = (xcb_input_motion_event_t *)ge;
 	struct tw_x11_output *output = tw_x11_output_from_id(x11, ev->event);
-	struct tw_event_pointer_motion_abs motion = {
+	struct tw_event_pointer_motion_abs abs = {
 		.dev = &output->pointer,
 	};
 	unsigned width, height;
@@ -120,12 +120,12 @@ handle_x11_motion(struct tw_x11_backend *x11, xcb_ge_generic_event_t *ge)
 
 	emitter = output->pointer.emitter;
 
-	motion.time_msec = ev->time;
-	motion.x = (double)(ev->event_x >> 16) / (float)width;
-	motion.y = (double)(ev->event_y >> 16) / (float)height;
-	motion.output = &output->output.device;
+	abs.time_msec = ev->time;
+	abs.x = (double)(ev->event_x >> 16) / (float)width;
+	abs.y = (double)(ev->event_y >> 16) / (float)height;
+	abs.output = &output->output.device;
 	if (emitter) {
-		wl_signal_emit(&emitter->pointer.motion_absolute, &motion);
+		tw_input_signal_emit(emitter, pointer.motion_absolute, &abs);
 		wl_signal_emit(&emitter->pointer.frame, &output->pointer);
 	}
 }

--- a/libtaiwins/engine/engine.c
+++ b/libtaiwins/engine/engine.c
@@ -191,6 +191,7 @@ tw_engine_create_global(struct wl_display *display, struct tw_backend *backend)
 	wl_signal_init(&engine->signals.seat_created);
 	wl_signal_init(&engine->signals.seat_focused);
 	wl_signal_init(&engine->signals.seat_remove);
+	wl_signal_init(&engine->signals.seat_input);
 	wl_signal_init(&engine->signals.output_created);
 	wl_signal_init(&engine->signals.output_remove);
 	wl_signal_init(&engine->signals.output_resized);

--- a/libtaiwins/engine/seat.c
+++ b/libtaiwins/engine/seat.c
@@ -104,6 +104,14 @@ notify_seat_remove_device(struct wl_listener *listener, void *data)
 }
 
 static void
+notify_seat_input_event(struct wl_listener *listener, void *data)
+{
+	struct tw_engine_seat *seat =
+		wl_container_of(listener, seat, sink.event);
+	wl_signal_emit(&seat->engine->signals.seat_input, seat);
+}
+
+static void
 notify_seat_focus_device(struct wl_listener *listener, void *data)
 {
 	struct tw_engine_seat *seat =
@@ -543,6 +551,8 @@ seat_install_default_listeners(struct tw_engine_seat *seat)
 	                         notify_seat_unfocus_device);
 	tw_signal_setup_listener(&seat->source.remove, &seat->sink.remove,
 	                         notify_seat_remove_device);
+	tw_signal_setup_listener(&seat->source.event, &seat->sink.event,
+	                         notify_seat_input_event);
 	seat_install_keyboard_listeners(seat);
 	seat_install_pointer_listeners(seat);
 	seat_install_touch_listeners(seat);

--- a/libtaiwins/input_device.c
+++ b/libtaiwins/input_device.c
@@ -135,6 +135,7 @@ void
 tw_input_source_init(struct tw_input_source *source)
 {
 	wl_signal_init(&source->remove);
+	wl_signal_init(&source->event);
 	//keyboard
 	wl_signal_init(&source->keyboard.key);
 	wl_signal_init(&source->keyboard.modifiers);
@@ -189,7 +190,7 @@ tw_input_device_notify_key(struct tw_input_device *dev,
 	updated = update_keyboard_modifier(dev);
 
 	if (dev->emitter)
-		wl_signal_emit(&dev->emitter->keyboard.key, event);
+		tw_input_signal_emit(dev->emitter, keyboard.key, event);
 	if (updated && dev->emitter) {
 		struct tw_event_keyboard_modifier mods = {
 			.dev = dev,
@@ -218,5 +219,6 @@ tw_input_device_notify_modifiers(struct tw_input_device *dev,
 	updated = update_keyboard_modifier(dev);
 
 	if (updated && dev->emitter)
-		wl_signal_emit(&dev->emitter->keyboard.modifiers, mod);
+		tw_input_signal_emit(dev->emitter, keyboard.modifiers,
+		                     mod);
 }

--- a/libtaiwins/libinput/device.c
+++ b/libtaiwins/libinput/device.c
@@ -90,8 +90,7 @@ handle_device_pointer_motion_event(struct tw_libinput_device *dev,
 			.unaccel_dy =
 			libinput_event_pointer_get_dy_unaccelerated(event),
 		};
-
-		wl_signal_emit(&emitter->pointer.motion, &motion);
+		tw_input_signal_emit(emitter, pointer.motion, &motion);
 		wl_signal_emit(&emitter->pointer.frame, &dev->base);
         }
 }
@@ -103,7 +102,7 @@ handle_device_pointer_motion_abs_event(struct tw_libinput_device *dev,
 	struct tw_input_source *emitter = dev->base.emitter;
 
         if (emitter && event) {
-		struct tw_event_pointer_motion_abs motion = {
+		struct tw_event_pointer_motion_abs abs = {
 			.dev = &dev->base,
 			.time_msec = libinput_event_pointer_get_time(event),
 			.output = request_output_device_from_libinput(dev),
@@ -112,8 +111,7 @@ handle_device_pointer_motion_abs_event(struct tw_libinput_device *dev,
 			.y = libinput_event_pointer_get_absolute_y_transformed(
 				event, 1),
 		};
-
-		wl_signal_emit(&emitter->pointer.motion_absolute, &motion);
+		tw_input_signal_emit(emitter, pointer.motion_absolute, &abs);
 		wl_signal_emit(&emitter->pointer.frame, &dev->base);
         }
 }
@@ -136,7 +134,7 @@ handle_device_pointer_button_event(struct tw_libinput_device *dev,
 			.button = libinput_event_pointer_get_button(event),
 			.time = libinput_event_pointer_get_time(event),
 		};
-		wl_signal_emit(&emitter->pointer.button, &button);
+		tw_input_signal_emit(emitter, pointer.button, &button);
 		wl_signal_emit(&emitter->pointer.frame, &dev->base);
         }
 }
@@ -174,7 +172,7 @@ handle_device_pointer_axis_event(struct tw_libinput_device *dev,
 		axis.delta_discrete =
 			libinput_event_pointer_get_axis_value_discrete(
 				event,LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL);
-		wl_signal_emit(&emitter->pointer.axis, &axis);
+		tw_input_signal_emit(emitter, pointer.axis, &axis);
 
 	} else if (libinput_event_pointer_has_axis(
 		           event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL)) {
@@ -184,8 +182,7 @@ handle_device_pointer_axis_event(struct tw_libinput_device *dev,
 		axis.delta_discrete =
 			libinput_event_pointer_get_axis_value_discrete(
 				event, LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL);
-		wl_signal_emit(&emitter->pointer.axis, &axis);
-
+		tw_input_signal_emit(emitter, pointer.axis, &axis);
 	}
 	wl_signal_emit(&emitter->pointer.frame, &dev->base);
 }
@@ -208,7 +205,7 @@ handle_device_pinch_gesture_begin(struct tw_libinput_device *dev,
 	gesture.time = libinput_event_gesture_get_time(event);
 	gesture.fingers = libinput_event_gesture_get_finger_count(event);
 
-	wl_signal_emit(&emitter->pointer.pinch_begin, &gesture);
+	tw_input_signal_emit(emitter, pointer.pinch_begin, &gesture);
 }
 
 static void
@@ -228,7 +225,7 @@ handle_device_pinch_gesture_update(struct tw_libinput_device *dev,
 	gesture.scale = libinput_event_gesture_get_dy(event);
 	gesture.rotation = libinput_event_gesture_get_angle_delta(event);
 
-	wl_signal_emit(&emitter->pointer.pinch_update, &gesture);
+	tw_input_signal_emit(emitter, pointer.pinch_update, &gesture);
 }
 
 static void
@@ -245,7 +242,7 @@ handle_device_pinch_gesture_end(struct tw_libinput_device *dev,
 	gesture.time = libinput_event_gesture_get_time(event);
 	gesture.cancelled = libinput_event_gesture_get_cancelled(event);
 
-	wl_signal_emit(&emitter->pointer.pinch_end, &gesture);
+	tw_input_signal_emit(emitter, pointer.pinch_end, &gesture);
 }
 
 static void
@@ -262,7 +259,7 @@ handle_device_swipe_gesture_begin(struct tw_libinput_device *dev,
 	gesture.time = libinput_event_gesture_get_time(event);
 	gesture.fingers = libinput_event_gesture_get_finger_count(event);
 
-	wl_signal_emit(&emitter->pointer.swipe_begin, &gesture);
+	tw_input_signal_emit(emitter, pointer.swipe_begin, &gesture);
 }
 
 static void
@@ -280,7 +277,7 @@ handle_device_swipe_gesture_update(struct tw_libinput_device *dev,
 	gesture.dx = libinput_event_gesture_get_dx(event);
 	gesture.dy = libinput_event_gesture_get_dy(event);
 
-	wl_signal_emit(&emitter->pointer.swipe_update, &gesture);
+	tw_input_signal_emit(emitter, pointer.swipe_update, &gesture);
 }
 
 static void
@@ -297,7 +294,7 @@ handle_device_swipe_gesture_end(struct tw_libinput_device *dev,
 	gesture.time = libinput_event_gesture_get_time(event);
 	gesture.cancelled = libinput_event_gesture_get_cancelled(event);
 
-	wl_signal_emit(&emitter->pointer.swipe_end, &gesture);
+	tw_input_signal_emit(emitter, pointer.swipe_end, &gesture);
 }
 
 /******************************************************************************
@@ -319,7 +316,7 @@ handle_device_touch_down_event(struct tw_libinput_device *dev,
 			.x = libinput_event_touch_get_x_transformed(event, 1),
 			.y = libinput_event_touch_get_y_transformed(event, 1),
 		};
-		wl_signal_emit(&emitter->touch.down, &down);
+		tw_input_signal_emit(emitter, touch.down, &down);
 	}
 }
 
@@ -338,7 +335,7 @@ handle_device_touch_motion_event(struct tw_libinput_device *dev,
 			.x = libinput_event_touch_get_x_transformed(event, 1),
 			.y = libinput_event_touch_get_y_transformed(event, 1),
 		};
-		wl_signal_emit(&emitter->touch.motion, &motion);
+		tw_input_signal_emit(emitter, touch.down, &motion);
 	}
 }
 
@@ -353,7 +350,7 @@ handle_device_touch_up_event(struct tw_libinput_device *dev,
 			.time = libinput_event_touch_get_time(event),
 			.touch_id = libinput_event_touch_get_seat_slot(event),
 		};
-		wl_signal_emit(&emitter->touch.up, &up);
+		tw_input_signal_emit(emitter, touch.up, &up);
 	}
 }
 


### PR DESCRIPTION
Emitting input device signals as well as an general input signal. This approach
is much cleaner than listening on every input signals and doing additional processing.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>