### PR TITLE
libinput: updating LEDS on key update

### DIFF
--- a/include/taiwins/input_device.h
+++ b/include/taiwins/input_device.h
@@ -118,7 +118,8 @@ struct tw_input_sink {
 };
 
 struct tw_keyboard_input {
-	xkb_led_mask_t depressed, latched, locked, group;
+	xkb_mod_mask_t depressed, latched, locked, group;
+	bool num_locked, scroll_locked, caps_locked;
 
 	struct xkb_keymap *keymap;
 	struct xkb_state *keystate;

--- a/libtaiwins/engine/seat.c
+++ b/libtaiwins/engine/seat.c
@@ -164,14 +164,11 @@ static uint32_t
 get_ledmask(struct tw_input_device *device)
 {
 	uint32_t mask = 0;
-	struct xkb_state *state = device->input.keyboard.keystate;
+	struct tw_keyboard_input *input = &device->input.keyboard;
 
-	if (xkb_state_led_name_is_active(state, XKB_LED_NAME_NUM))
-		mask |= TW_LED_NUM_LOCK;
-	if (xkb_state_led_name_is_active(state, XKB_LED_NAME_CAPS))
-		mask |= TW_LED_CAPS_LOCK;
-	if (xkb_state_led_name_is_active(state, XKB_LED_NAME_SCROLL))
-		mask |= TW_LED_SCROLL_LOCK;
+	mask |= input->num_locked ? TW_LED_NUM_LOCK : 0;
+	mask |= input->caps_locked ? TW_LED_CAPS_LOCK : 0;
+	mask |= input->scroll_locked ? TW_LED_SCROLL_LOCK : 0;
 	return mask;
 }
 

--- a/libtaiwins/libinput/device.c
+++ b/libtaiwins/libinput/device.c
@@ -50,6 +50,19 @@ request_output_device_from_libinput(struct tw_libinput_device *dev)
  * keyboard event
  *****************************************************************************/
 
+static inline void
+handle_device_update_leds(struct tw_libinput_device *dev)
+{
+	uint32_t leds = 0;
+	struct tw_keyboard_input *input = &dev->base.input.keyboard;
+
+	leds |= input->num_locked ? LIBINPUT_LED_NUM_LOCK : 0;
+	leds |= input->caps_locked ? LIBINPUT_LED_CAPS_LOCK : 0;
+	leds |= input->scroll_locked ? LIBINPUT_LED_SCROLL_LOCK : 0;
+
+	libinput_device_led_update(dev->libinput, leds);
+}
+
 static void
 handle_device_keyboard_event(struct tw_libinput_device *dev,
                              struct libinput_event_keyboard *event)
@@ -67,6 +80,8 @@ handle_device_keyboard_event(struct tw_libinput_device *dev,
 	key.time = libinput_event_keyboard_get_time(event);
 
 	tw_input_device_notify_key(&dev->base, &key);
+	handle_device_update_leds(dev);
+
 }
 
 /******************************************************************************


### PR DESCRIPTION
Using libinput functions to update LEDS, our implementation is somewhat awkward
right now. LEDs are update on one keyboard at a time, but we can't do it
without a callback to set LEDs.

Signed-off-by: Xichen Zhou <xzhou@xeechou.net>