### PR TITLE
supporting secondary output

### DIFF
--- a/compositor/config/config.c
+++ b/compositor/config/config.c
@@ -186,6 +186,8 @@ tw_config_table_apply_output(struct tw_config_table *t,
 		return;
 	if (co->enabled.valid)
 		tw_output_device_enable(od, co->enabled.enable);
+	if (co->primary.valid)
+		tw_output_device_set_primary(od, co->primary.enable);
 	if (co->transform.valid)
 		tw_output_device_set_transform(od, co->transform.transform);
 	if (co->width.valid && co->height.valid)

--- a/compositor/config/config_lua.c
+++ b/compositor/config/config_lua.c
@@ -429,9 +429,27 @@ _lua_read_display_enable(lua_State *L, struct tw_config_table *t, int idx)
 }
 
 static int
+_lua_read_display_primary(lua_State *L, struct tw_config_table *t, int idx)
+{
+	bool primary = true;
+	lua_getfield(L, 3, "primary");
+	if (lua_isboolean(L, -1)) {
+		primary = lua_toboolean(L, -1);
+		lua_pop(L, 1);
+	} else if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return 0;
+	}
+	SET_PENDING(&t->outputs[idx].primary, enable, primary);
+	tw_config_table_dirty(t, true);
+	return 0;
+}
+
+static int
 _lua_read_display(lua_State *L, struct tw_config_table *t, uint32_t idx)
 {
 	_lua_read_display_enable(L, t, idx);
+	_lua_read_display_primary(L, t, idx);
 	_lua_read_display_scale(L, t, idx);
 	_lua_read_display_position(L, t, idx);
 	_lua_read_display_mode(L, t, idx);

--- a/compositor/config/config_types.h
+++ b/compositor/config/config_types.h
@@ -58,7 +58,7 @@ struct tw_config_output {
 	pending_intval_t scale, posx, posy;
 	pending_uintval_t width, height;
 	pending_transform_t transform;
-	pending_boolean_t enabled;
+	pending_boolean_t enabled, primary;
 };
 
 #ifdef __cplusplus

--- a/compositor/output.h
+++ b/compositor/output.h
@@ -37,7 +37,7 @@ extern "C" {
 
 //we shall see how this works
 struct tw_server_output {
-	struct tw_engine_output *output;
+	struct tw_output_device *device;
 
 	struct {
 		/** average frame time in microseconds */

--- a/include/taiwins/engine.h
+++ b/include/taiwins/engine.h
@@ -33,6 +33,7 @@
 #include <taiwins/objects/surface.h>
 #include <taiwins/objects/layers.h>
 #include <taiwins/objects/output.h>
+#include <taiwins/objects/xdg_output.h>
 #include <taiwins/objects/data_device.h>
 #include <taiwins/objects/compositor.h>
 #include <taiwins/objects/cursor.h>
@@ -133,12 +134,14 @@ struct tw_engine {
 	struct tw_presentation presentation;
 	struct tw_viewporter viewporter;
 	struct tw_gestures_manager gestures_manager;
+	struct tw_xdg_output_manager output_manager;
 
 	/* listeners */
 	struct {
 		struct wl_listener display_destroy;
 		struct wl_listener new_output;
 		struct wl_listener new_input;
+		struct wl_listener new_xdg_output;
 	} listeners;
         /* signals */
 	struct {

--- a/include/taiwins/engine.h
+++ b/include/taiwins/engine.h
@@ -66,7 +66,7 @@ struct tw_engine_output {
 	struct tw_output_device *device;
 	struct tw_output *tw_output;
 
-	int id, cloning;
+	int id;
 	struct wl_list link; /* tw_engine:heads */
 
 	struct tw_cursor_constrain constrain;

--- a/include/taiwins/engine.h
+++ b/include/taiwins/engine.h
@@ -111,7 +111,8 @@ struct tw_engine {
 	bool started;
 
 	/* outputs */
-	struct wl_list heads, pending_heads; /* tw_engine_output:links */
+	struct wl_list heads; /* tw_engine_output:links */
+	struct wl_list pending_heads; /* pending heads are secondary output */
 	uint32_t output_pool;
 	struct tw_engine_output outputs[32];
 
@@ -145,9 +146,11 @@ struct tw_engine {
 	} listeners;
         /* signals */
 	struct {
+		/* output signals work on primary outputs */
 		struct wl_signal output_created;
 		struct wl_signal output_resized;
 		struct wl_signal output_remove;
+		/* seat signals */
 		struct wl_signal seat_created;
 		struct wl_signal seat_focused;
 		struct wl_signal seat_remove;

--- a/include/taiwins/objects/xdg_output.h
+++ b/include/taiwins/objects/xdg_output.h
@@ -35,15 +35,23 @@ struct tw_xdg_output_manager {
 	struct wl_display *display;
 	struct wl_global *global;
 	struct wl_listener display_destroy_listener;
-	struct wl_signal xdg_output_requested;
+
+	struct wl_list outputs;
+	struct wl_signal new_output;
 };
 
-struct tw_xdg_output_info_event {
+struct tw_event_xdg_output_info {
 	struct wl_resource *wl_output;
 	const char *name, *desription;
 	int32_t x, y;
 	uint32_t width, height;
 };
+
+void
+tw_xdg_output_send_info(struct wl_resource *xdg_output,
+                        struct tw_event_xdg_output_info *event);
+struct wl_resource *
+tw_xdg_output_get_wl_output(struct wl_resource *xdg_output);
 
 bool
 tw_xdg_output_manager_init(struct tw_xdg_output_manager *manager,

--- a/include/taiwins/output_device.h
+++ b/include/taiwins/output_device.h
@@ -45,7 +45,7 @@ struct tw_output_device_mode {
 };
 
 struct tw_output_device_state {
-	bool enabled;
+	bool enabled, primary; /* primary output by default */
 	float scale;
 	int32_t gx, gy; /**< x,y position in global space */
 	enum wl_output_transform transform;
@@ -97,6 +97,9 @@ struct tw_output_device {
 
 void
 tw_output_device_enable(struct tw_output_device *device, bool enable);
+
+void
+tw_output_device_set_primary(struct tw_output_device *device, bool primary);
 
 void
 tw_output_device_set_transform(struct tw_output_device *device,

--- a/libtaiwins/engine/engine.c
+++ b/libtaiwins/engine/engine.c
@@ -81,6 +81,14 @@ notify_new_output(struct wl_listener *listener, void *data)
 	tw_engine_new_output(engine, device);
 }
 
+static void
+notify_new_xdg_output(struct wl_listener *listener, void *data)
+{
+	struct wl_resource *xdg_output = data;
+	struct tw_engine *engine =
+		wl_container_of(listener, engine, listeners.new_xdg_output);
+	tw_engine_new_xdg_output(engine, xdg_output);
+}
 
 static void
 notify_engine_release(struct wl_listener *listener, void *data)
@@ -110,6 +118,9 @@ engine_init_globals(struct tw_engine *engine)
 		return false;
 	if (!tw_gestures_manager_init(&engine->gestures_manager,
 	                              engine->display))
+		return false;
+	if (!tw_xdg_output_manager_init(&engine->output_manager,
+	                                engine->display))
 		return false;
 
 	tw_layers_manager_init(&engine->layers_manager, engine->display);
@@ -162,6 +173,9 @@ tw_engine_create_global(struct wl_display *display, struct tw_backend *backend)
 	tw_signal_setup_listener(&backend->signals.new_input,
 	                         &engine->listeners.new_input,
 	                         notify_new_input);
+	tw_signal_setup_listener(&engine->output_manager.new_output,
+	                         &engine->listeners.new_xdg_output,
+	                         notify_new_xdg_output);
 	//signals
 	wl_signal_init(&engine->signals.seat_created);
 	wl_signal_init(&engine->signals.seat_focused);

--- a/libtaiwins/engine/internal.h
+++ b/libtaiwins/engine/internal.h
@@ -26,6 +26,7 @@
 #include <taiwins/input_device.h>
 #include <taiwins/output_device.h>
 #include <taiwins/render_context.h>
+#include <wayland-server.h>
 
 #ifdef  __cplusplus
 extern "C" {
@@ -37,7 +38,9 @@ tw_engine_seat_find_create(struct tw_engine *engine, unsigned int id);
 bool
 tw_engine_new_output(struct tw_engine *engine,
                      struct tw_output_device *device);
-
+void
+tw_engine_new_xdg_output(struct tw_engine *engine,
+                         struct wl_resource *resource);
 void
 tw_engine_seat_add_input_device(struct tw_engine_seat *seat,
                                 struct tw_input_device *device);

--- a/libtaiwins/engine/output.c
+++ b/libtaiwins/engine/output.c
@@ -228,7 +228,6 @@ tw_engine_new_output(struct tw_engine *engine,
 		tw_logl_level(TW_LOG_ERRO, "too many displays");
 	output = &engine->outputs[id];
 	output->id = id;
-	output->cloning = -1;
 	output->engine = engine;
 	output->device = device;
 	output->tw_output = tw_output_create(engine->display);

--- a/libtaiwins/objects/meson.build
+++ b/libtaiwins/objects/meson.build
@@ -43,6 +43,7 @@ taiwins_obj_srcs = [
   'plane.c',
   'cursor.c',
   'popup_grab.c',
+  'xdg_output.c',
   'desktop/desktop.c',
   'desktop/desktop_wl_shell.c',
   'desktop/desktop_xdg_shell.c',

--- a/libtaiwins/objects/xdg_output.c
+++ b/libtaiwins/objects/xdg_output.c
@@ -21,7 +21,6 @@
 
 #include <assert.h>
 #include <wayland-server.h>
-#include <wayland-util.h>
 #include <wayland-xdg-output-server-protocol.h>
 
 #include <taiwins/objects/xdg_output.h>
@@ -115,19 +114,19 @@ tw_xdg_output_send_info(struct wl_resource *xdg_output,
 {
 	assert(wl_resource_instance_of(xdg_output, &zxdg_output_v1_interface,
 	                               &xdg_output_impl));
+	assert(tw_xdg_output_get_wl_output(xdg_output) == event->wl_output);
 
-	if (event->name && event->width && event->height) {
-		zxdg_output_v1_send_name(xdg_output, event->name);
-		zxdg_output_v1_send_logical_position(xdg_output,
-		                                     event->x, event->y);
-		zxdg_output_v1_send_logical_size(xdg_output,
-		                                 event->width, event->height);
-		if (event->desription)
-			zxdg_output_v1_send_description(xdg_output,
-			                                event->desription);
-		zxdg_output_v1_send_done(xdg_output);
-	}
-	//TODO send wl_output_done on version 3
+	zxdg_output_v1_send_name(xdg_output, event->name);
+	zxdg_output_v1_send_logical_position(xdg_output,
+	                                     event->x, event->y);
+	zxdg_output_v1_send_logical_size(xdg_output,
+	                                 event->width, event->height);
+	if (event->desription)
+		zxdg_output_v1_send_description(xdg_output,
+		                                event->desription);
+	zxdg_output_v1_send_done(xdg_output);
+	if (wl_resource_get_version(xdg_output) >= 3)
+		wl_output_send_done(event->wl_output);
 }
 
 WL_EXPORT bool

--- a/libtaiwins/objects/xdg_output.c
+++ b/libtaiwins/objects/xdg_output.c
@@ -19,7 +19,8 @@
  *
  */
 
-#include <wayland-server-core.h>
+#include <assert.h>
+#include <wayland-server.h>
 #include <wayland-util.h>
 #include <wayland-xdg-output-server-protocol.h>
 
@@ -30,10 +31,16 @@
 #define XDG_OUTPUT_MAN_VERSION 1
 #define XDG_OUTPUT_VERSION 3
 
-
 static const struct zxdg_output_v1_interface xdg_output_impl = {
 	.destroy = tw_resource_destroy_common,
 };
+
+static void
+handle_destroy_xdg_output(struct wl_resource *resource)
+{
+	wl_resource_set_user_data(resource, NULL);
+	tw_reset_wl_list(wl_resource_get_link(resource));
+}
 
 static void
 handle_get_xdg_output(struct wl_client *client,
@@ -41,9 +48,6 @@ handle_get_xdg_output(struct wl_client *client,
                       uint32_t id,
                       struct wl_resource *output)
 {
-	struct tw_xdg_output_info_event event = {
-		.wl_output = output,
-	};
 	struct tw_xdg_output_manager *manager =
 		wl_resource_get_user_data(resource);
 	struct wl_resource *output_resource =
@@ -54,20 +58,11 @@ handle_get_xdg_output(struct wl_client *client,
 		return;
 	}
 	wl_resource_set_implementation(output_resource, &xdg_output_impl,
-	                               NULL, NULL);
+	                               output, handle_destroy_xdg_output);
 
-	wl_signal_emit(&manager->xdg_output_requested, &event);
-	if (event.name && event.width && event.height) {
-		zxdg_output_v1_send_name(output_resource, event.name);
-		zxdg_output_v1_send_logical_position(output_resource,
-		                                     event.x, event.y);
-		zxdg_output_v1_send_logical_size(output_resource,
-		                                 event.width, event.height);
-		if (event.desription)
-			zxdg_output_v1_send_description(output_resource,
-			                                event.desription);
-		zxdg_output_v1_send_done(output_resource);
-	}
+	wl_signal_emit(&manager->new_output, output_resource);
+	wl_list_insert(&manager->outputs,
+	               wl_resource_get_link(output_resource));
 }
 
 static const struct zxdg_output_manager_v1_interface xdg_output_man_impl = {
@@ -106,6 +101,35 @@ handle_display_destroy(struct wl_listener *listener, void *data)
 	wl_global_destroy(manager->global);
 }
 
+WL_EXPORT struct wl_resource *
+tw_xdg_output_get_wl_output(struct wl_resource *xdg_output)
+{
+	assert(wl_resource_instance_of(xdg_output, &zxdg_output_v1_interface,
+	                               &xdg_output_impl));
+	return wl_resource_get_user_data(xdg_output);
+}
+
+WL_EXPORT void
+tw_xdg_output_send_info(struct wl_resource *xdg_output,
+                        struct tw_event_xdg_output_info *event)
+{
+	assert(wl_resource_instance_of(xdg_output, &zxdg_output_v1_interface,
+	                               &xdg_output_impl));
+
+	if (event->name && event->width && event->height) {
+		zxdg_output_v1_send_name(xdg_output, event->name);
+		zxdg_output_v1_send_logical_position(xdg_output,
+		                                     event->x, event->y);
+		zxdg_output_v1_send_logical_size(xdg_output,
+		                                 event->width, event->height);
+		if (event->desription)
+			zxdg_output_v1_send_description(xdg_output,
+			                                event->desription);
+		zxdg_output_v1_send_done(xdg_output);
+	}
+	//TODO send wl_output_done on version 3
+}
+
 WL_EXPORT bool
 tw_xdg_output_manager_init(struct tw_xdg_output_manager *manager,
                            struct wl_display *display)
@@ -121,7 +145,8 @@ tw_xdg_output_manager_init(struct tw_xdg_output_manager *manager,
 	manager->display_destroy_listener.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display,
 	                                &manager->display_destroy_listener);
-	wl_signal_init(&manager->xdg_output_requested);
+	wl_signal_init(&manager->new_output);
+	wl_list_init(&manager->outputs);
 	return true;
 }
 

--- a/libtaiwins/output_device.c
+++ b/libtaiwins/output_device.c
@@ -38,6 +38,7 @@ output_device_state_init(struct tw_output_device_state *state,
                          struct tw_output_device *device)
 {
 	state->enabled = true;
+	state->primary = true;
 	state->scale = 1.0;
 	state->current_mode.w = 0;
 	state->current_mode.h = 0;
@@ -165,6 +166,12 @@ WL_EXPORT void
 tw_output_device_enable(struct tw_output_device *device, bool enable)
 {
 	device->pending.enabled = enable;
+}
+
+WL_EXPORT void
+tw_output_device_set_primary(struct tw_output_device *device, bool primary)
+{
+	device->pending.primary = primary;
 }
 
 WL_EXPORT void

--- a/libtaiwins/shell/shell.c
+++ b/libtaiwins/shell/shell.c
@@ -467,8 +467,6 @@ shell_send_default_config(struct tw_shell *shell)
 	struct tw_engine *engine = shell->engine;
 
 	wl_list_for_each(output, &engine->heads, link) {
-		if (output->cloning >= 0)
-			continue;
 		shell_send_output_config(shell, output,
 		                         TAIWINS_SHELL_OUTPUT_MSG_CONNECTED);
 	}


### PR DESCRIPTION
secondary output, is used to represent a output that is not visible to clients, merely use for mirroring